### PR TITLE
[codex] Fix Windows setup compatibility

### DIFF
--- a/scripts/ctf-website/kb_router.py
+++ b/scripts/ctf-website/kb_router.py
@@ -74,7 +74,7 @@ def main():
         print(f"     Signals: {', '.join(entry.get('signals', [])[:5])}")
         for f in entry.get("files", []):
             full = os.path.join(TECHNIQUES_DIR, f)
-            exists = "✓" if os.path.exists(full) else "✗"
+            exists = "[OK]" if os.path.exists(full) else "[MISSING]"
             print(f"     {exists} kb/ctf-website/techniques/{f}")
         print()
 

--- a/scripts/misc/ai_toolcheck.py
+++ b/scripts/misc/ai_toolcheck.py
@@ -54,10 +54,10 @@ def main():
             found = os.path.exists(fullpath)
 
         if found:
-            print(f"  ✓ {name}")
+            print(f"  [OK] {name}")
             installed += 1
         else:
-            print(f"  ✗ {name} — install: .\\scripts\\misc\\install_tools.ps1")
+            print(f"  [MISSING] {name} - install: .\\scripts\\misc\\install_tools.ps1")
             missing += 1
 
     print(f"\n  {installed} installed, {missing} missing")

--- a/scripts/misc/lab_healthcheck.py
+++ b/scripts/misc/lab_healthcheck.py
@@ -34,7 +34,7 @@ def check_directories():
     for d in REQUIRED_DIRS:
         path = os.path.join(ROOT, d)
         exists = os.path.isdir(path)
-        status = "✓" if exists else "✗ MISSING"
+        status = "[OK]" if exists else "[MISSING]"
         if not exists:
             ok = False
         print(f"  {status}: {d}/")
@@ -48,10 +48,10 @@ def check_platform_dirs():
         for parent in ["samples", "projects", "exports", "notes", "reports", "patches", "scripts"]:
             path = os.path.join(ROOT, parent, area)
             if not os.path.isdir(path):
-                print(f"  ✗ MISSING: {parent}/{area}/")
+                print(f"  [MISSING]: {parent}/{area}/")
                 ok = False
     if ok:
-        print("  ✓ All platform directories present")
+        print("  [OK] All platform directories present")
     return ok
 
 
@@ -68,7 +68,7 @@ def main():
         print("\n=== Tool Check ===")
         subprocess.run([sys.executable, toolcheck])
 
-    print(f"\n{'✓ All checks passed' if dirs_ok and platform_ok else '✗ Issues found — see above'}")
+    print(f"\n{'[OK] All checks passed' if dirs_ok and platform_ok else '[ERROR] Issues found - see above'}")
 
 
 if __name__ == "__main__":

--- a/tools/skills/mcp/ReverseLabToolsMCP/reverselab_mcp/config.py
+++ b/tools/skills/mcp/ReverseLabToolsMCP/reverselab_mcp/config.py
@@ -65,10 +65,7 @@ def _find_exe(base: Path, names: list[str], label: str) -> Path:
         candidate = base / name
         if candidate.exists():
             return candidate
-    raise FileNotFoundError(
-        f"{label} not found in {base}. Tried: {names}. "
-        f"Run: .\\scripts\\misc\\install_tools.ps1"
-    )
+    return base / names[0]
 
 
 # Ghidra (version-flexible)

--- a/tools/skills/mcp/ReverseLabToolsMCP/reverselab_mcp/tools/android_mumu.py
+++ b/tools/skills/mcp/ReverseLabToolsMCP/reverselab_mcp/tools/android_mumu.py
@@ -117,7 +117,8 @@ def _shell(command: str, serial: str = "", as_root: bool = False, timeout: int =
     except Exception:
         if not _is_default_mumu_serial(serial):
             raise
-        wrapped = command if as_root else f"su -c \"{command.replace('\"', '\\\"')}\""
+        escaped = command.replace('"', '\\"')
+        wrapped = command if as_root else f'su -c "{escaped}"'
         code, stdout, stderr = _mumu_cli(["sh", "--vmindex", _mumu_vmindex(), "--cmd", wrapped], timeout=timeout, check=True)
     return {
         "command": command,


### PR DESCRIPTION
## Summary
- replace non-ASCII status glyphs in Windows-facing scripts with ASCII-safe markers
- allow ReverseLabToolsMCP to import even when optional Cutter/DiE tools are not installed yet
- fix an Android MuMu f-string syntax issue on current Python versions

## Validation
- `python scripts\misc\lab_healthcheck.py`
- `python scripts\ctf-website\kb_router.py jwt`
- `uv run --script tools/skills/mcp/ReverseLabToolsMCP/reverse_lab_tools_mcp.py --workspace-crud-test`

## Notes
- Local Procmon binaries were installed under ignored `tools/windows/ProcessMonitor/` and are not included in this PR.
- Cutter, PE-bear, and DiE downloads were blocked by GitHub API rate limiting on the proxy exit IP.
