### PR TITLE
Add Web CTF autopilot controller

### DIFF
--- a/.claude/commands/ctf-24h.md
+++ b/.claude/commands/ctf-24h.md
@@ -1,0 +1,112 @@
+---
+description: 24h unattended Web CTF loop runner
+argument-hint: <target-url-or-domain> [case-name]
+allowed-tools: Bash, Read, Write, Edit, MultiEdit, Glob, Grep, LS, WebFetch, WebSearch
+---
+
+# /ctf-24h
+
+在 Claude Code 中对授权 Web/CTF 目标启动 24 小时全流程推进。
+
+这个命令不是单纯提示词。它要求配合 Claude Code 的 `/loop` 使用：
+
+- `/loop` 负责不中断地重复调度。
+- `.claude/workflows/ctf-24h-round.js` 负责每次只跑一轮有界动作。
+- `cases/<case>/ai_manifest.json` 负责 checkpoint / resume / stop 判断。
+
+审批/权限不在这个提示词里解决；运行 Claude Code 时应启用无人值守/自动审批配置，例如允许本命令声明的工具、Bash、文件读写和网络探测。命令内部不等待人工确认。
+
+如果本地还没配置无人值守 runner，先在仓库根目录执行：
+
+```bash
+python3 scripts/misc/setup_unattended_ctf_runner.py --overwrite
+```
+
+该命令会生成本地 `.codex/` 配置和 `.claude/settings.local.json`。
+
+## 参数
+
+```
+/ctf-24h <target-url-or-domain> [case-name]
+```
+
+如果没有给 `case-name`，用目标 host 生成去标识化 slug。所有真实请求/响应、截图、日志和 flag 只写入本地
+`cases/`、`exports/ctf-website/`、`notes/ctf-website/`、`reports/ctf-website/`，不要提交这些私有产物。
+
+## 执行协议
+
+1. 先解析 `$ARGUMENTS` 为：
+   - `target`: 第一个参数，URL 或 domain。
+   - `caseName`: 第二个参数；缺省时从 target host 生成 slug。
+2. 先读：
+   - `AI-USAGE.md`
+   - `boards/ctf-website/AI-USAGE.md`
+   - `kb/ctf-website/techniques/attack-network.md`
+3. 初始化 case（如不存在）：
+   ```bash
+   python3 scripts/ctf-website/ctf_intake.py "$CASE_NAME" --url "$TARGET" --root .
+   ```
+4. 然后调用单轮 workflow：
+   ```text
+   workflow: ctf-24h-round
+   args:
+     target: <target>
+     caseName: <caseName>
+     maxActions: 4
+     execute: true
+   ```
+5. 每发现一个信号，立即查知识库：
+   ```bash
+   python3 scripts/ctf-website/kb_router.py "<signal>"
+   ```
+6. 按攻击网并行推进，不要只走单链：
+   - Recon / route discovery / JS endpoint mining
+   - Auth/session/JWT
+   - Injection: SQLi/NoSQLi/SSTI/HPP/CRLF
+   - File/LFI/upload
+   - SSRF/internal metadata
+   - CVE fingerprint -> graph -> chain
+   - Flag path validation
+7. 每轮都要写回：
+   - `cases/<case>/ai_manifest.json`
+   - `notes/ctf-website/<case>/`
+   - `reports/ctf-website/<case>/`
+   - 必要的 raw request 到 `exports/ctf-website/<case>/requests/`
+
+## `/loop` 使用方式
+
+在 Claude Code 中推荐这样启动：
+
+```text
+/loop /ctf-24h https://target.example/ my-case
+```
+
+如果你的 Claude Code 版本要求先进入 loop，再输入命令，则使用：
+
+```text
+/loop
+/ctf-24h https://target.example/ my-case
+```
+
+每轮 workflow 必须输出以下状态之一：
+
+- `CONTINUE`: 还有可执行路径，下一轮继续。
+- `DONE`: 已拿到 flag 或完成报告，停止 `/loop`。
+- `EXHAUSTED`: 24h 预算耗尽、全部路径耗尽、目标长期不可达或运行器缺少关键能力且无替代路径。
+
+## 停止条件
+
+- 已拿到 flag 并完成复现报告。
+- 24 小时预算耗尽。
+- 目标不可达且重试/备用路径均有证据。
+- 攻击网全部路径都有证据表明不可达/不可利用。
+
+## 输出要求
+
+最终输出中文摘要，包含：
+
+- case 路径
+- 已确认攻击链
+- flag/关键证据位置
+- 失败路径与 dead ends
+- 后续可继续的入口

--- a/.claude/workflows/ctf-24h-round.js
+++ b/.claude/workflows/ctf-24h-round.js
@@ -1,0 +1,210 @@
+export const meta = {
+  name: 'ctf-24h-round',
+  description: 'Web CTF 24h loop 的单轮有状态 workflow：初始化/读取 manifest → 执行一轮推进 → 写 checkpoint → 返回 CONTINUE/DONE/EXHAUSTED',
+  phases: [
+    { title: '阶段一：读取 checkpoint' },
+    { title: '阶段二：单轮自动推进' },
+    { title: '阶段三：Agent 攻击网推进' },
+    { title: '阶段四：写回与停止判断' },
+  ],
+}
+
+// ================================================================
+// args 规范：
+//   string             → target URL/domain
+//   object.target      → 目标 URL/domain
+//   object.caseName    → case 名；默认从 target 生成
+//   object.manifest    → ai_manifest.json 路径；有则优先使用
+//   object.maxActions  → ctf_autopilot 单轮最多动作数，默认 4
+//   object.execute     → 是否执行 allowlist 动作，默认 true
+//   object.stopOnExhausted → 全路径耗尽时停止，默认 true
+// ================================================================
+
+const rawTarget = typeof args === 'string' ? args : args?.target || ''
+const target = rawTarget || 'https://target.example/'
+const safeTarget = target
+  .replace(/^https?:\/\//, '')
+  .replace(/[^a-zA-Z0-9._-]+/g, '-')
+  .replace(/^-+|-+$/g, '')
+  .toLowerCase()
+const caseName = typeof args === 'object' && args?.caseName ? args.caseName : safeTarget || 'ctf-target'
+const manifest =
+  typeof args === 'object' && args?.manifest
+    ? args.manifest
+    : `cases/${caseName}/ai_manifest.json`
+const maxActions = typeof args === 'object' && args?.maxActions ? args.maxActions : 4
+const execute = !(typeof args === 'object' && args?.execute === false)
+const stopOnExhausted = !(typeof args === 'object' && args?.stopOnExhausted === false)
+
+phase('阶段一：读取 checkpoint')
+
+const checkpoint = await agent(
+  `你是 Claude Code /loop 中的一轮 Web CTF controller。当前目标不是一次性跑完 24 小时，而是完成一个有界 round，写 checkpoint，然后返回明确状态。全流程无人值守，不等待人工审批；平台权限/审批由 Claude Code 或 Codex 启动参数负责。
+
+## 输入
+
+- Target: ${target}
+- Case name: ${caseName}
+- Manifest path: ${manifest}
+- Max actions: ${maxActions}
+- Execute allowlist actions: ${execute}
+
+## 必读
+
+1. 读取 \`AI-USAGE.md\`
+2. 读取 \`boards/ctf-website/AI-USAGE.md\`
+3. 读取 \`kb/ctf-website/techniques/attack-network.md\`
+
+## 初始化 / 恢复
+
+如果 \`${manifest}\` 不存在：
+
+\`\`\`bash
+python3 scripts/ctf-website/ctf_intake.py "${caseName}" --url "${target}" --root .
+\`\`\`
+
+然后定位实际生成的 \`cases/*/ai_manifest.json\`。如果 case 名因日期前缀不同导致路径不一致，以脚本输出为准，并在本轮报告中说明。
+
+如果 manifest 已存在，先读取它的 \`autopilot.last_round_id\`、\`next_actions\`、\`evidence\`、\`dead_ends\`，不要从头开始。
+
+## 输出
+
+返回 JSON，不要 Markdown：
+
+{
+  "manifest": "<实际 manifest 路径>",
+  "case": "<case>",
+  "checkpoint_loaded": true,
+  "last_round_id": "<如果有>",
+  "known_next_actions": [],
+  "known_dead_ends": []
+}`,
+  { label: 'checkpoint', phase: '阶段一：读取 checkpoint' },
+)
+
+phase('阶段二：单轮自动推进')
+
+const autopilot = await agent(
+  `基于上一阶段 checkpoint，执行一轮确定性 autopilot。不要开启无限循环；只跑一轮。
+
+## 优先命令
+
+\`\`\`bash
+python3 scripts/ctf-website/ctf_autopilot.py ${manifest} --max-actions ${maxActions} ${execute ? '--execute' : ''}
+\`\`\`
+
+如果 manifest 路径与 checkpoint 输出不同，改用 checkpoint 中的实际路径。
+
+## 要求
+
+1. 命令失败时读取错误，修正路径或依赖问题后重试一次。
+2. 不要把真实请求/响应输出到最终回答；原始证据写入 \`exports/ctf-website/<case>/\`。
+3. 总结本轮 autopilot 的 executed/planned/agent_required/error 动作。
+
+## 输出
+
+返回 JSON，不要 Markdown：
+
+{
+  "manifest": "<实际 manifest 路径>",
+  "executed": [],
+  "planned": [],
+  "agent_required": [],
+  "errors": []
+}`,
+  { label: 'autopilot-round', phase: '阶段二：单轮自动推进' },
+)
+
+phase('阶段三：Agent 攻击网推进')
+
+const attackRound = await agent(
+  `现在作为 Web CTF Agent 做一轮有界攻击网推进。你不是只做提示词总结，要实际读取文件、运行安全探测命令、保存证据。
+
+## 输入
+
+Target: ${target}
+Case: ${caseName}
+Manifest: ${manifest}
+Autopilot result:
+${autopilot}
+
+## 约束
+
+1. 每发现一个信号（JWT、SQLi、SSRF、LFI、SSTI、CVE、upload、auth 等）先运行：
+   \`python3 scripts/ctf-website/kb_router.py "<signal>"\`
+   然后读取排名靠前的 KB 技术文件。
+2. 按 \`kb/ctf-website/techniques/attack-network.md\` 多路径推进。
+3. 本轮最多选择 2 条最高优先路径深入验证，避免无限发散。
+4. 所有证据落盘：
+   - raw request: \`exports/ctf-website/<case>/requests/\`
+   - notes: \`notes/ctf-website/<case>/\`
+   - report fragments: \`reports/ctf-website/<case>/\`
+5. 如果拿到 flag 或等价通关证据，写入本地 report，并在 \`ai_manifest.json\` 的 evidence 中记录 artifact 路径。
+6. 如果当前路径需要登录态、验证码、浏览器态或额外权限，不要等待人工；记录到 dead_ends 或 next_round_focus，然后自动切换其他攻击网路径。
+7. 只有全部路径耗尽或 24h 预算耗尽才返回 EXHAUSTED；否则继续返回 CONTINUE。
+
+## 输出
+
+返回 JSON，不要 Markdown：
+
+{
+  "status": "CONTINUE|DONE|EXHAUSTED",
+  "reason": "",
+  "manifest": "<实际 manifest 路径>",
+  "evidence_added": [],
+  "dead_ends_added": [],
+  "signals_seen": [],
+  "next_round_focus": []
+}`,
+  { label: 'attack-network-round', phase: '阶段三：Agent 攻击网推进' },
+)
+
+phase('阶段四：写回与停止判断')
+
+const final = await agent(
+  `整合本轮结果并写回 manifest/notes。必须只输出一个明确 loop 状态。不要把“等待人工确认/人工审批”作为状态；无人值守执行失败时，记录证据并切换路径。
+
+## 输入
+
+Checkpoint:
+${checkpoint}
+
+Autopilot:
+${autopilot}
+
+Attack round:
+${attackRound}
+
+## 写回要求
+
+1. 读取实际 \`ai_manifest.json\`。
+2. 如果 attack round 有 \`evidence_added\` / \`dead_ends_added\` / \`next_round_focus\`，合并到 manifest。
+3. 在 case 或 reports 目录写一份本轮摘要，例如 \`reports/ctf-website/<case>/loop-round-<timestamp>.md\`。
+4. 输出状态：
+   - DONE：已拿到 flag / 已生成完整复现报告。
+   - EXHAUSTED：预算耗尽、全路径耗尽、目标长期不可达或关键依赖缺失且无替代路径。
+   - CONTINUE：仍有 next_round_focus 或 pending hypotheses。
+5. stopOnExhausted 当前为 ${stopOnExhausted}；如果 false，即使路径暂时耗尽也生成新的 recon/fingerprint/route-discovery 焦点并返回 CONTINUE。
+
+## 最终输出格式
+
+只输出以下格式，不要额外解释：
+
+STATUS: CONTINUE|DONE|EXHAUSTED
+MANIFEST: <path>
+CASE: <case>
+ROUND_REPORT: <path>
+REASON: <one-line reason>
+NEXT: <one-line next focus or empty>`,
+  { label: 'loop-status', phase: '阶段四：写回与停止判断' },
+)
+
+return {
+  target,
+  caseName,
+  manifest,
+  checkpoint,
+  autopilot,
+  attackRound,
+  final,
+}

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ tools/ctf-website/_downloads/
 
 # Local agent / IDE config (not part of public release)
 .codex/
+.claude/settings.local.json
 .serena/
 
 # Generated reports (may contain machine paths); keep README stubs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,24 @@
 4. **按攻击网规划多路径** — 不要只走一条链，从不同入口并行探测
 5. **看 MCP 工具映射** — 技术文件末尾的"## MCP 工具映射"表标注了可自动化的步骤；优先用 MCP 工具而非手动执行
 
+### Claude Code / Codex 24h 长跑
+
+如果用户要求“24 小时自动完成全流程 CTF”或类似不中断打靶，不能只依赖提示词。
+按文件夹内置的 loop/checkpoint 协议执行：
+
+1. Claude Code 优先使用 `/loop /ctf-24h <target> [case]`。
+2. `/loop` 每轮调用 `.claude/workflows/ctf-24h-round.js`，不要让单个 workflow 阻塞 24 小时。
+3. 每轮只做有界动作，输出 `STATUS: CONTINUE|DONE|EXHAUSTED`。
+4. `cases/<case>/ai_manifest.json` 是恢复点；中断后先读 manifest 的
+   `autopilot.last_round_id`、`next_actions`、`evidence`、`dead_ends`，再继续。
+5. Codex 没有 Claude workflow runner 时，使用同一 manifest 协议：循环执行
+   `python3 scripts/ctf-website/ctf_autopilot.py <manifest> --max-actions 4 --execute`，
+   再由 Agent 按攻击网完成本轮 AI 判断和证据写回。
+6. 无人值守审批/权限由运行器配置负责。需要时先执行
+   `python3 scripts/misc/setup_unattended_ctf_runner.py --overwrite`，生成本地
+   `.codex/` 与 `.claude/settings.local.json`。
+7. 真实目标、flag、请求响应、截图、日志只保存在本地 case/export/report 目录，禁止提交。
+
 ## APK/Android 知识库
 
 分析 Android APK/DEX 时，**必须先查知识库再动手**：

--- a/AI-USAGE.md
+++ b/AI-USAGE.md
@@ -24,7 +24,38 @@
 7. **证据落盘**：原始输出进 `exports/<board>/`，笔记进 `notes/<board>/`，最终报告进 `reports/<board>/`。
 8. **可回放**：记录关键输入、输出路径、版本和时间。
 
-## 2.1 公共仓库边界
+## 2.1 Claude Code / Codex 长跑模式
+
+本仓库首先是给 Claude Code / Codex 读取的工作文件夹。需要“24 小时不中断 CTF”
+时，不要只靠提示词，也不要让单个 workflow 阻塞 24 小时；使用：
+
+```
+/loop  →  .claude/workflows/ctf-24h-round.js  →  cases/<case>/ai_manifest.json
+```
+
+规则：
+
+1. `/loop` 是外层调度器，负责重复调用单轮任务。
+2. `ctf-24h-round` 每次只做一轮有界动作，必须输出 `STATUS: CONTINUE|DONE|EXHAUSTED`。
+3. `ai_manifest.json` 是唯一恢复点；每轮都要写 `autopilot.rounds[]`、`evidence[]`、
+   `dead_ends[]` 和 `next_actions[]`。
+4. 中断/重启后，Claude Code 或 Codex 先读同一个 manifest，再继续下一轮，不从头开始。
+5. 真实 target、请求响应、flag、截图和日志只留在本地 `cases/` / `exports/` / `reports/`，
+   不进入公开提交。
+
+无人值守 runner 配置：
+
+```bash
+python3 scripts/misc/setup_unattended_ctf_runner.py --overwrite
+```
+
+该脚本在本文件夹内生成本地 `.codex/` 配置和 `.claude/settings.local.json`：
+
+- Codex: `approval_policy = "never"`，`sandbox_mode = "danger-full-access"`。
+- Claude Code: 本地 settings 允许 Bash、文件读写、搜索和 Web 工具。
+- 这些文件是本地运行配置，不作为公开制品提交。
+
+## 2.2 公共仓库边界
 
 不要把私人工作区的 `cases/`、samples、日志、真实目标、凭据、用户目录或个人信息
 迁入本仓库。通用发现应去标识化后写入 `kb/`；发布前运行

--- a/boards/ctf-website/AI-USAGE.md
+++ b/boards/ctf-website/AI-USAGE.md
@@ -13,3 +13,38 @@
 
 - 工具安装状态查看：`tools/ctf-website/installed-tools.md`
 - 工具 checklist：运行 `python scripts/misc/ai_toolcheck.py` 或 `.\scripts\ctf-website\ctf_toolcheck.ps1`
+
+## 自动化入口选择
+
+| 目标 | 入口 | 说明 |
+|---|---|---|
+| 域名/站点级一次性评估 | `.claude/workflows/ctf-full-pipeline.js` | 资产发现 → DoS 面 → 漏洞挖掘 → 验证 → 综合报告；适合 agent workflow 环境。 |
+| 单题/靶场 24h 可恢复推进 | `scripts/ctf-website/ctf_intake.py` + `scripts/ctf-website/ctf_autopilot.py` | 先生成 `ai_manifest.json`，再按预算循环执行 allowlist 动作并写回 checkpoint。 |
+
+### 24h CTF Autopilot
+
+初始化 case：
+
+```bash
+python scripts/ctf-website/ctf_intake.py <case-name> --url "https://target.example/" --root .
+```
+
+单轮规划/检查（默认 dry-run，只写 checkpoint，不执行网络/CVE 扩展动作）：
+
+```bash
+python scripts/ctf-website/ctf_autopilot.py cases/<case>/ai_manifest.json --max-actions 4
+```
+
+24 小时循环执行：
+
+```bash
+python scripts/ctf-website/ctf_autopilot.py cases/<case>/ai_manifest.json \
+  --loop --budget-hours 24 --max-rounds 96 --interval-seconds 900 --execute
+```
+
+规则：
+
+1. Autopilot 只执行 allowlist 动作：HTTP baseline、fingerprint 模板创建、fingerprint→CVE pipeline、CVE graph/chain 重建。
+2. SQLi、XSS、SSRF、认证态等高上下文动作仍记录为 `manual_required`，由 Agent 依据 KB 技术文件继续推进。
+3. 每轮写回 `ai_manifest.json` 的 `autopilot.rounds[]`、`next_actions` 和 `evidence[]`，中断后可直接再次运行同一命令恢复。
+4. 默认 CVE pipeline 使用 `--no-network`；需要实时 NVD enrichment 时增加 `--allow-network-cve`。

--- a/boards/ctf-website/AI-USAGE.md
+++ b/boards/ctf-website/AI-USAGE.md
@@ -19,7 +19,8 @@
 | 目标 | 入口 | 说明 |
 |---|---|---|
 | 域名/站点级一次性评估 | `.claude/workflows/ctf-full-pipeline.js` | 资产发现 → DoS 面 → 漏洞挖掘 → 验证 → 综合报告；适合 agent workflow 环境。 |
-| 单题/靶场 24h 可恢复推进 | `scripts/ctf-website/ctf_intake.py` + `scripts/ctf-website/ctf_autopilot.py` | 先生成 `ai_manifest.json`，再按预算循环执行 allowlist 动作并写回 checkpoint。 |
+| Claude Code 24h 可恢复推进 | `/loop /ctf-24h <target> [case]` | `/loop` 负责不中断调度，`ctf-24h-round` 每轮推进并写 checkpoint。 |
+| Codex / 无 workflow runner fallback | `scripts/ctf-website/ctf_intake.py` + `scripts/ctf-website/ctf_autopilot.py` | 先生成 `ai_manifest.json`，再循环单轮动作并由 Agent 继续攻击网判断。 |
 
 ### 24h CTF Autopilot
 
@@ -35,7 +36,13 @@ python scripts/ctf-website/ctf_intake.py <case-name> --url "https://target.examp
 python scripts/ctf-website/ctf_autopilot.py cases/<case>/ai_manifest.json --max-actions 4
 ```
 
-24 小时循环执行：
+Claude Code 中推荐用 `/loop + workflow`：
+
+```text
+/loop /ctf-24h https://target.example/ my-case
+```
+
+无 Claude workflow runner 时可用 Python fallback 做 checkpoint 心跳：
 
 ```bash
 python scripts/ctf-website/ctf_autopilot.py cases/<case>/ai_manifest.json \
@@ -44,7 +51,8 @@ python scripts/ctf-website/ctf_autopilot.py cases/<case>/ai_manifest.json \
 
 规则：
 
-1. Autopilot 只执行 allowlist 动作：HTTP baseline、fingerprint 模板创建、fingerprint→CVE pipeline、CVE graph/chain 重建。
-2. SQLi、XSS、SSRF、认证态等高上下文动作仍记录为 `manual_required`，由 Agent 依据 KB 技术文件继续推进。
-3. 每轮写回 `ai_manifest.json` 的 `autopilot.rounds[]`、`next_actions` 和 `evidence[]`，中断后可直接再次运行同一命令恢复。
-4. 默认 CVE pipeline 使用 `--no-network`；需要实时 NVD enrichment 时增加 `--allow-network-cve`。
+1. 不让单个 workflow 阻塞 24 小时；每轮必须有界执行并返回 `CONTINUE|DONE|EXHAUSTED`。
+2. Autopilot 只执行 allowlist 动作：HTTP baseline、fingerprint 模板创建、fingerprint→CVE pipeline、CVE graph/chain 重建。
+3. SQLi、XSS、SSRF、认证态等高上下文动作记录为 `agent_required`，由下一轮 Agent 依据 KB 技术文件自动推进。
+4. 每轮写回 `ai_manifest.json` 的 `autopilot.rounds[]`、`next_actions` 和 `evidence[]`，中断后可直接再次运行同一命令恢复。
+5. 默认 CVE pipeline 使用 `--no-network`；需要实时 NVD enrichment 时增加 `--allow-network-cve`。

--- a/scripts/ctf-website/ctf_autopilot.py
+++ b/scripts/ctf-website/ctf_autopilot.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""
+Stateful Web CTF autopilot controller.
+
+The controller turns ctf_ai_next.py's advisory plan into repeatable rounds with
+budget, checkpoint, and manifest write-back.  It deliberately executes only a
+small allowlist of deterministic actions; everything else is recorded as a
+manual/agent task for the next round.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import time
+import urllib.parse
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import ctf_ai_next
+import ctf_intake
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA = "reverselab.ctf_website.ai_manifest.v1"
+AUTOPILOT_SCHEMA = "reverselab.ctf_website.autopilot.v1"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def save_manifest(path: Path, manifest: dict[str, Any]) -> None:
+    path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def resolve_manifest_path(raw_path: str) -> Path:
+    path = Path(raw_path).expanduser()
+    if not path.is_absolute():
+        path = ROOT / path
+    path = path.resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"manifest not found: {path}")
+    if path.name != "ai_manifest.json":
+        raise ValueError(f"expected ai_manifest.json, got: {path}")
+    try:
+        path.relative_to(ROOT)
+    except ValueError as exc:
+        raise ValueError(f"manifest is outside workspace root: {path}") from exc
+    return path
+
+
+def resolve_workspace_path(raw_path: str, fallback: Path) -> Path:
+    if not raw_path:
+        return fallback
+    path = Path(raw_path).expanduser()
+    if not path.is_absolute():
+        path = ROOT / path
+    return path.resolve()
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(ROOT))
+    except ValueError:
+        return str(path.resolve())
+
+
+def ensure_manifest_shape(manifest: dict[str, Any], manifest_path: Path) -> None:
+    manifest.setdefault("schema", SCHEMA)
+    manifest.setdefault("case", manifest_path.parent.name)
+    manifest.setdefault("board", "ctf-website")
+    manifest.setdefault("target", {})
+    manifest.setdefault("paths", {})
+    manifest.setdefault("baseline", {})
+    manifest.setdefault("parsed", {"links": [], "scripts": [], "forms": []})
+    manifest.setdefault("hypotheses", [])
+    manifest.setdefault("next_actions", [])
+    manifest.setdefault("evidence", [])
+    manifest.setdefault("dead_ends", [])
+
+    paths = manifest["paths"]
+    paths.setdefault("case", str(manifest_path.parent))
+    case_slug = str(manifest.get("case") or manifest_path.parent.name)
+    paths.setdefault("exports", str(ROOT / "exports" / "ctf-website" / case_slug))
+    paths.setdefault("reports", str(ROOT / "reports" / "ctf-website" / case_slug))
+
+
+def append_evidence(manifest: dict[str, Any], evidence: dict[str, Any]) -> None:
+    manifest.setdefault("evidence", []).append(
+        {
+            "time": utc_now(),
+            "source": "ctf_autopilot",
+            **evidence,
+        }
+    )
+
+
+def case_path(manifest: dict[str, Any], manifest_path: Path) -> Path:
+    return resolve_workspace_path(str(manifest.get("paths", {}).get("case", "")), manifest_path.parent)
+
+
+def reports_path(manifest: dict[str, Any], manifest_path: Path) -> Path:
+    fallback = ROOT / "reports" / "ctf-website" / str(manifest.get("case") or manifest_path.parent.name)
+    path = resolve_workspace_path(str(manifest.get("paths", {}).get("reports", "")), fallback)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def collect_http_baseline(manifest: dict[str, Any], manifest_path: Path) -> dict[str, Any]:
+    target_url = str(manifest.get("target", {}).get("url") or "").strip()
+    if not target_url:
+        return {"status": "skipped", "reason": "target.url is empty"}
+
+    baseline = ctf_intake.fetch(target_url)
+    parser = ctf_intake.LinkParser()
+    parser.feed(baseline.get("body_text", ""))
+    base = baseline.get("final_url") or target_url
+    manifest["baseline"] = {k: v for k, v in baseline.items() if k != "body_text"}
+    manifest["parsed"] = {
+        "links": sorted({urllib.parse.urljoin(base, value) for value in parser.links}),
+        "scripts": sorted({urllib.parse.urljoin(base, value) for value in parser.scripts}),
+        "forms": parser.forms,
+    }
+    manifest["error"] = ""
+
+    exports_dir = resolve_workspace_path(
+        str(manifest.get("paths", {}).get("exports", "")),
+        ROOT / "exports" / "ctf-website" / str(manifest.get("case") or manifest_path.parent.name),
+    )
+    exports_dir.mkdir(parents=True, exist_ok=True)
+    body_path = exports_dir / "baseline_body.html"
+    if baseline.get("body_text"):
+        body_path.write_text(baseline["body_text"], encoding="utf-8")
+
+    append_evidence(
+        manifest,
+        {
+            "type": "http_baseline",
+            "url": target_url,
+            "status_code": baseline.get("status"),
+            "elapsed_ms": baseline.get("elapsed_ms"),
+            "body_size": baseline.get("body_size"),
+            "artifact": display_path(body_path) if body_path.exists() else "",
+        },
+    )
+    return {
+        "status": "executed",
+        "handler": "collect_http_baseline",
+        "status_code": baseline.get("status"),
+        "links": len(manifest["parsed"]["links"]),
+        "scripts": len(manifest["parsed"]["scripts"]),
+        "forms": len(manifest["parsed"]["forms"]),
+    }
+
+
+def create_fingerprint_template(manifest: dict[str, Any], manifest_path: Path) -> dict[str, Any]:
+    out_path = case_path(manifest, manifest_path) / "fingerprints.json"
+    if out_path.exists():
+        return {"status": "skipped", "handler": "create_fingerprint_template", "reason": "already exists", "path": str(out_path)}
+
+    template_path = ROOT / "templates" / "cases" / "fingerprints.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    if template_path.exists():
+        shutil.copyfile(template_path, out_path)
+        data = json.loads(out_path.read_text(encoding="utf-8"))
+    else:
+        data = {"target": "", "url": "", "timestamp": "", "fingerprints": []}
+
+    target_url = str(manifest.get("target", {}).get("url") or "")
+    data["target"] = manifest.get("case", "")
+    data["url"] = target_url
+    data["timestamp"] = utc_now()
+    out_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    manifest["fingerprints"] = str(out_path)
+    append_evidence(
+        manifest,
+        {
+            "type": "fingerprint_template",
+            "artifact": display_path(out_path),
+            "note": "Fill product/version evidence before running CVE correlation.",
+        },
+    )
+    return {"status": "executed", "handler": "create_fingerprint_template", "path": str(out_path)}
+
+
+def run_command(cmd: list[str], timeout: int) -> dict[str, Any]:
+    result = subprocess.run(
+        cmd,
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return {
+        "command": cmd,
+        "exit_code": result.returncode,
+        "stdout": result.stdout[-8192:],
+        "stderr": result.stderr[-4096:],
+    }
+
+
+def run_fingerprint_cve_pipeline(
+    manifest: dict[str, Any],
+    manifest_path: Path,
+    *,
+    no_network_cve: bool,
+    timeout: int,
+) -> dict[str, Any]:
+    fingerprint_path = ctf_ai_next.existing_fingerprint_path(manifest, manifest_path)
+    if not fingerprint_path:
+        return {"status": "skipped", "handler": "run_fingerprint_cve_pipeline", "reason": "fingerprints.json is missing"}
+
+    report_dir = reports_path(manifest, manifest_path)
+    cve_out = report_dir / "cve"
+    graph_out = report_dir / "cve-graph"
+    chain_out = report_dir / "cve-chain"
+    pipeline_out = report_dir / "fingerprint-cve"
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "ctf-website" / "fingerprint_cve_pipeline.py"),
+        "--fingerprints",
+        fingerprint_path,
+        "--cve-out",
+        str(cve_out),
+        "--graph-out",
+        str(graph_out),
+        "--chain-out",
+        str(chain_out),
+        "--pipeline-out",
+        str(pipeline_out),
+        "--per-fingerprint-limit",
+        "5",
+        "--max-cves",
+        "10",
+    ]
+    if no_network_cve:
+        cmd.append("--no-network")
+
+    result = run_command(cmd, timeout)
+    manifest["cve_reports"] = str(cve_out)
+    append_evidence(
+        manifest,
+        {
+            "type": "cve_pipeline",
+            "fingerprints": str(Path(fingerprint_path).resolve()),
+            "exit_code": result["exit_code"],
+            "reports": display_path(report_dir),
+        },
+    )
+    return {"status": "executed", "handler": "run_fingerprint_cve_pipeline", **result}
+
+
+def rebuild_cve_graph_chain(manifest: dict[str, Any], manifest_path: Path, *, timeout: int) -> dict[str, Any]:
+    cve_reports = str(manifest.get("cve_reports") or manifest.get("paths", {}).get("cve_reports") or "")
+    if not cve_reports:
+        return {"status": "skipped", "handler": "rebuild_cve_graph_chain", "reason": "cve_reports path is missing"}
+
+    report_dir = reports_path(manifest, manifest_path)
+    graph_out = report_dir / "cve-graph"
+    chain_out = report_dir / "cve-chain"
+    graph = run_command(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "ctf-website" / "cve_graph.py"),
+            "--from-dir",
+            cve_reports,
+            "--out",
+            str(graph_out),
+        ],
+        timeout,
+    )
+    chain = run_command(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "ctf-website" / "cve_chain_planner.py"),
+            "--from-dir",
+            cve_reports,
+            "--out",
+            str(chain_out),
+        ],
+        timeout,
+    )
+    append_evidence(
+        manifest,
+        {
+            "type": "cve_graph_chain",
+            "cve_reports": cve_reports,
+            "graph_exit_code": graph["exit_code"],
+            "chain_exit_code": chain["exit_code"],
+        },
+    )
+    return {"status": "executed", "handler": "rebuild_cve_graph_chain", "graph": graph, "chain": chain}
+
+
+def execute_action(
+    action: dict[str, Any],
+    manifest: dict[str, Any],
+    manifest_path: Path,
+    *,
+    no_network_cve: bool,
+    command_timeout: int,
+) -> dict[str, Any]:
+    action_name = str(action.get("action") or "")
+    try:
+        if action_name == "Collect HTTP baseline":
+            return collect_http_baseline(manifest, manifest_path)
+        if action_name == "Create version fingerprint evidence file":
+            return create_fingerprint_template(manifest, manifest_path)
+        if action_name == "Run fingerprint-to-CVE graph and chain pipeline":
+            return run_fingerprint_cve_pipeline(
+                manifest,
+                manifest_path,
+                no_network_cve=no_network_cve,
+                timeout=command_timeout,
+            )
+        if action_name == "Rebuild CVE correlation graph and multi-CVE chain plan":
+            return rebuild_cve_graph_chain(manifest, manifest_path, timeout=command_timeout)
+        return {
+            "status": "manual_required",
+            "reason": "no deterministic allowlist handler for this action",
+        }
+    except subprocess.TimeoutExpired as exc:
+        return {"status": "error", "error": f"timeout after {exc.timeout}s", "handler": action_name}
+    except Exception as exc:
+        return {"status": "error", "error": repr(exc), "handler": action_name}
+
+
+def select_actions(plan_result: dict[str, Any], max_actions: int) -> list[dict[str, Any]]:
+    actions = list(plan_result.get("actions") or [])
+    return actions[: max(0, max_actions)]
+
+
+def update_autopilot_state(
+    manifest: dict[str, Any],
+    *,
+    round_record: dict[str, Any],
+    budget_seconds: int,
+    max_rounds: int,
+    execute: bool,
+) -> None:
+    state = manifest.setdefault("autopilot", {})
+    state.setdefault("schema", AUTOPILOT_SCHEMA)
+    state.setdefault("started_at", round_record["started_at"])
+    state["updated_at"] = utc_now()
+    state["status"] = "running" if execute else "dry_run"
+    state["budget"] = {
+        "budget_seconds": budget_seconds,
+        "max_rounds": max_rounds,
+        "execute": execute,
+    }
+    state.setdefault("rounds", []).append(round_record)
+    state["last_round_id"] = round_record["round_id"]
+    manifest["next_actions"] = [
+        item.get("action", "")
+        for item in round_record.get("actions", [])
+        if item.get("action")
+    ]
+
+
+def run_round(
+    manifest_path: Path,
+    *,
+    max_actions: int = 4,
+    execute: bool = False,
+    no_network_cve: bool = True,
+    command_timeout: int = 600,
+    budget_seconds: int = 86400,
+    max_rounds: int = 1,
+) -> dict[str, Any]:
+    manifest = load_manifest(manifest_path)
+    ensure_manifest_shape(manifest, manifest_path)
+
+    plan_result = ctf_ai_next.plan(manifest, manifest_path)
+    selected = select_actions(plan_result, max_actions)
+    started_at = utc_now()
+    round_id = "R-" + datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    action_records: list[dict[str, Any]] = []
+
+    for action in selected:
+        execution = (
+            execute_action(
+                action,
+                manifest,
+                manifest_path,
+                no_network_cve=no_network_cve,
+                command_timeout=command_timeout,
+            )
+            if execute
+            else {
+                "status": "planned",
+                "handler_available": str(action.get("action") or "")
+                in {
+                    "Collect HTTP baseline",
+                    "Create version fingerprint evidence file",
+                    "Run fingerprint-to-CVE graph and chain pipeline",
+                    "Rebuild CVE correlation graph and multi-CVE chain plan",
+                },
+            }
+        )
+        action_records.append({**action, "execution": execution})
+
+    round_record = {
+        "round_id": round_id,
+        "started_at": started_at,
+        "finished_at": utc_now(),
+        "execute": execute,
+        "action_count": len(action_records),
+        "actions": action_records,
+    }
+    update_autopilot_state(
+        manifest,
+        round_record=round_record,
+        budget_seconds=budget_seconds,
+        max_rounds=max_rounds,
+        execute=execute,
+    )
+    save_manifest(manifest_path, manifest)
+
+    return {
+        "manifest": str(manifest_path),
+        "case": manifest.get("case"),
+        "round": round_record,
+        "plan_action_count": plan_result.get("action_count", 0),
+        "selected_action_count": len(action_records),
+        "execute": execute,
+    }
+
+
+def run_loop(
+    manifest_path: Path,
+    *,
+    budget_seconds: int,
+    max_rounds: int,
+    max_actions: int,
+    interval_seconds: int,
+    execute: bool,
+    no_network_cve: bool,
+    command_timeout: int,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + max(0, budget_seconds)
+    rounds: list[dict[str, Any]] = []
+    stop_reason = "max_rounds"
+
+    for index in range(max_rounds):
+        if time.monotonic() >= deadline:
+            stop_reason = "budget_exhausted"
+            break
+        result = run_round(
+            manifest_path,
+            max_actions=max_actions,
+            execute=execute,
+            no_network_cve=no_network_cve,
+            command_timeout=command_timeout,
+            budget_seconds=budget_seconds,
+            max_rounds=max_rounds,
+        )
+        rounds.append(result)
+        if index == max_rounds - 1:
+            break
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            stop_reason = "budget_exhausted"
+            break
+        time.sleep(min(max(0, interval_seconds), remaining))
+
+    return {
+        "manifest": str(manifest_path),
+        "round_count": len(rounds),
+        "stop_reason": stop_reason,
+        "execute": execute,
+        "rounds": rounds,
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Run a stateful Web CTF autopilot round or loop.")
+    parser.add_argument("manifest", help="Path to cases/<case>/ai_manifest.json")
+    parser.add_argument("--loop", action="store_true", help="Run repeated rounds until budget/max-rounds is reached.")
+    parser.add_argument("--budget-hours", type=float, default=24.0, help="Loop budget in hours; default 24.")
+    parser.add_argument("--budget-seconds", type=int, default=0, help="Override --budget-hours for tests/smoke runs.")
+    parser.add_argument("--max-rounds", type=int, default=24, help="Maximum number of rounds in loop mode.")
+    parser.add_argument("--max-actions", type=int, default=4, help="Maximum actions selected per round.")
+    parser.add_argument("--interval-seconds", type=int, default=900, help="Sleep between loop rounds.")
+    parser.add_argument("--execute", action="store_true", help="Execute allowlisted actions; default records a dry-run plan.")
+    parser.add_argument("--allow-network-cve", action="store_true", help="Allow live CVE enrichment network calls.")
+    parser.add_argument("--command-timeout", type=int, default=600, help="Timeout for each subprocess action.")
+    args = parser.parse_args(argv)
+
+    manifest_path = resolve_manifest_path(args.manifest)
+    budget_seconds = args.budget_seconds or int(args.budget_hours * 3600)
+    if args.loop:
+        result = run_loop(
+            manifest_path,
+            budget_seconds=budget_seconds,
+            max_rounds=args.max_rounds,
+            max_actions=args.max_actions,
+            interval_seconds=args.interval_seconds,
+            execute=args.execute,
+            no_network_cve=not args.allow_network_cve,
+            command_timeout=args.command_timeout,
+        )
+    else:
+        result = run_round(
+            manifest_path,
+            max_actions=args.max_actions,
+            execute=args.execute,
+            no_network_cve=not args.allow_network_cve,
+            command_timeout=args.command_timeout,
+            budget_seconds=budget_seconds,
+            max_rounds=1,
+        )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/ctf-website/ctf_autopilot.py
+++ b/scripts/ctf-website/ctf_autopilot.py
@@ -325,8 +325,8 @@ def execute_action(
         if action_name == "Rebuild CVE correlation graph and multi-CVE chain plan":
             return rebuild_cve_graph_chain(manifest, manifest_path, timeout=command_timeout)
         return {
-            "status": "manual_required",
-            "reason": "no deterministic allowlist handler for this action",
+            "status": "agent_required",
+            "reason": "no deterministic allowlist handler; queue for the next AI-driven attack round",
         }
     except subprocess.TimeoutExpired as exc:
         return {"status": "error", "error": f"timeout after {exc.timeout}s", "handler": action_name}

--- a/scripts/misc/setup_unattended_ctf_runner.py
+++ b/scripts/misc/setup_unattended_ctf_runner.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Generate local Claude Code / Codex profiles for unattended Web CTF loops.
+
+The generated files are machine-local runner configuration.  They are meant to
+live in this workspace folder and are ignored by git when possible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+CODEX_PROMPT = """# CTF Optimized Agent Prompt
+
+你正在 open-reverselab 文件夹内运行。默认目标是授权 CTF/lab 自动化。
+
+## Unattended loop protocol
+
+- 不等待人工审批；运行器层面的 approval/sandbox 配置已允许自动执行。
+- 24h Web CTF 使用 `/loop + ctf-24h-round + ai_manifest.json` 模式。
+- 单轮任务必须有界执行，输出 `STATUS: CONTINUE|DONE|EXHAUSTED`。
+- `cases/<case>/ai_manifest.json` 是恢复点；中断后读取它继续，不从头开始。
+- 每发现信号先读 `kb/ctf-website/techniques/attack-network.md`，再用
+  `scripts/ctf-website/kb_router.py "<signal>"` 路由技术文档。
+- 非 Python allowlist 动作标记为 `agent_required`，由下一轮 Agent 自动处理，不交给人。
+
+## Evidence
+
+- 原始请求/响应、截图、flag 和日志只写入本地 `cases/`、`exports/`、`reports/`。
+- 不把真实目标、凭据、Cookie、token、flag 或个人路径提交到公开仓库。
+"""
+
+
+CODEX_CONFIG = """model_instructions_file = "ctf_optimized.md"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+
+[mcp_servers.reverse_lab_tools]
+command = "uv"
+args = [
+  "run",
+  "--project",
+  "tools/skills/mcp/ReverseLabToolsMCP",
+  "python",
+  "tools/skills/mcp/ReverseLabToolsMCP/reverse_lab_tools_mcp.py",
+]
+"""
+
+
+CLAUDE_SETTINGS = {
+    "permissions": {
+        "allow": [
+            "Bash(*)",
+            "Read(*)",
+            "Write(*)",
+            "Edit(*)",
+            "MultiEdit(*)",
+            "Glob(*)",
+            "Grep(*)",
+            "LS(*)",
+            "WebFetch(*)",
+            "WebSearch(*)",
+        ],
+        "deny": [],
+    }
+}
+
+
+def write_text(path: Path, content: str, overwrite: bool) -> str:
+    if path.exists() and not overwrite:
+        return "exists"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return "written"
+
+
+def write_json(path: Path, payload: dict, overwrite: bool) -> str:
+    return write_text(path, json.dumps(payload, ensure_ascii=False, indent=2) + "\n", overwrite)
+
+
+def ensure_gitignore_entries(overwrite: bool) -> str:
+    gitignore = ROOT / ".gitignore"
+    entries = [".codex/", ".claude/settings.local.json"]
+    if not gitignore.exists():
+        gitignore.write_text("\n".join(entries) + "\n", encoding="utf-8")
+        return "written"
+
+    text = gitignore.read_text(encoding="utf-8")
+    changed = False
+    for entry in entries:
+        if entry not in text:
+            text = text.rstrip() + "\n" + entry + "\n"
+            changed = True
+    if changed and overwrite:
+        gitignore.write_text(text, encoding="utf-8")
+        return "updated"
+    return "ok" if not changed else "needs-update"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Create unattended CTF runner profiles for Claude Code and Codex.")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite existing local runner files.")
+    parser.add_argument("--skip-gitignore", action="store_true", help="Do not update .gitignore for local runner files.")
+    args = parser.parse_args()
+
+    outputs = {
+        "codex_config": write_text(ROOT / ".codex" / "config.toml", CODEX_CONFIG, args.overwrite),
+        "codex_ctf_config": write_text(ROOT / ".codex" / "ctf.config.toml", CODEX_CONFIG, args.overwrite),
+        "codex_prompt": write_text(ROOT / ".codex" / "ctf_optimized.md", CODEX_PROMPT, args.overwrite),
+        "claude_settings": write_json(ROOT / ".claude" / "settings.local.json", CLAUDE_SETTINGS, args.overwrite),
+    }
+    if not args.skip_gitignore:
+        outputs["gitignore"] = ensure_gitignore_entries(overwrite=True)
+
+    print(json.dumps({"root": str(ROOT), "outputs": outputs}, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/cases/ai_manifest.schema-note.md
+++ b/templates/cases/ai_manifest.schema-note.md
@@ -1,29 +1,85 @@
 # AI Manifest Schema
 
-Case 目录的 AI 可读索引文件结构说明。
+Case 目录的 AI 可读索引文件结构说明。Web CTF 当前使用
+`reverselab.ctf_website.ai_manifest.v1`，文件名固定为
+`ai_manifest.json`。
 
-## manifest.json 格式
+## ai_manifest.json 格式
 
 ```json
 {
-  "case_id": "",
-  "board": "",
-  "status": "",
-  "created": "",
-  "updated": "",
-  "targets": [],
-  "files": {
-    "samples": [],
-    "projects": [],
-    "exports": [],
-    "notes": [],
-    "reports": [],
-    "patches": [],
-    "scripts": []
+  "schema": "reverselab.ctf_website.ai_manifest.v1",
+  "case": "2026-07-example",
+  "board": "ctf-website",
+  "target": {
+    "url": "https://target.example/"
   },
-  "findings": [],
-  "open_questions": []
+  "paths": {
+    "case": "cases/2026-07-example",
+    "exports": "exports/ctf-website/example",
+    "notes": "notes/ctf-website/example",
+    "reports": "reports/ctf-website/example",
+    "scripts": "scripts/ctf-website/example"
+  },
+  "baseline": {
+    "url": "",
+    "final_url": "",
+    "status": 200,
+    "elapsed_ms": 0,
+    "headers": {},
+    "body_size": 0
+  },
+  "parsed": {
+    "links": [],
+    "scripts": [],
+    "forms": []
+  },
+  "hypotheses": [
+    {
+      "id": "H-001",
+      "class": "recon",
+      "claim": "Map hidden routes and APIs",
+      "status": "pending"
+    }
+  ],
+  "next_actions": [],
+  "evidence": [],
+  "dead_ends": [],
+  "autopilot": {
+    "schema": "reverselab.ctf_website.autopilot.v1",
+    "started_at": "",
+    "updated_at": "",
+    "status": "dry_run / running",
+    "budget": {
+      "budget_seconds": 86400,
+      "max_rounds": 96,
+      "execute": false
+    },
+    "last_round_id": "R-YYYYMMDD-HHMMSS",
+    "rounds": [
+      {
+        "round_id": "R-YYYYMMDD-HHMMSS",
+        "started_at": "",
+        "finished_at": "",
+        "execute": false,
+        "action_count": 0,
+        "actions": []
+      }
+    ]
+  }
 }
 ```
 
-AI 进入 case 目录后应首先读取此文件以获取全局视图。
+## 状态转换约定
+
+1. `ctf_intake.py` 创建初始 manifest、目录树和 HTTP baseline。
+2. `ctf_ai_next.py` 只读 manifest 并生成下一步计划。
+3. `ctf_autopilot.py` 读取计划，选择 P0/P1/P2 动作，执行 allowlist 动作或标记
+   `manual_required`，然后写回：
+   - `autopilot.rounds[]`：每轮计划/执行/checkpoint。
+   - `next_actions[]`：下一轮优先动作摘要。
+   - `evidence[]`：HTTP baseline、fingerprint 模板、CVE pipeline 等证据。
+4. Agent/人工完成非 allowlist 动作后，应补充 `evidence[]` 或 `dead_ends[]`，再跑下一轮 autopilot。
+
+AI 进入 case 目录后应首先读取 `ai_manifest.json` 获取全局视图和最近一轮
+`autopilot.last_round_id`。

--- a/templates/cases/ai_manifest.schema-note.md
+++ b/templates/cases/ai_manifest.schema-note.md
@@ -75,11 +75,11 @@ Case 目录的 AI 可读索引文件结构说明。Web CTF 当前使用
 1. `ctf_intake.py` 创建初始 manifest、目录树和 HTTP baseline。
 2. `ctf_ai_next.py` 只读 manifest 并生成下一步计划。
 3. `ctf_autopilot.py` 读取计划，选择 P0/P1/P2 动作，执行 allowlist 动作或标记
-   `manual_required`，然后写回：
+   `agent_required`，然后写回：
    - `autopilot.rounds[]`：每轮计划/执行/checkpoint。
    - `next_actions[]`：下一轮优先动作摘要。
    - `evidence[]`：HTTP baseline、fingerprint 模板、CVE pipeline 等证据。
-4. Agent/人工完成非 allowlist 动作后，应补充 `evidence[]` 或 `dead_ends[]`，再跑下一轮 autopilot。
+4. Agent 完成非 allowlist 动作后，应补充 `evidence[]` 或 `dead_ends[]`，再跑下一轮 autopilot。
 
 AI 进入 case 目录后应首先读取 `ai_manifest.json` 获取全局视图和最近一轮
 `autopilot.last_round_id`。

--- a/tests/test_ctf_autopilot.py
+++ b/tests/test_ctf_autopilot.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = ROOT / "scripts" / "ctf-website"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import ctf_autopilot  # noqa: E402
+
+
+def write_manifest(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def test_run_round_dry_run_writes_checkpoint(tmp_path):
+    manifest_path = tmp_path / "ai_manifest.json"
+    write_manifest(
+        manifest_path,
+        {
+            "schema": "reverselab.ctf_website.ai_manifest.v1",
+            "case": "autopilot-dry-run",
+            "board": "ctf-website",
+            "target": {"url": "http://example.test/"},
+            "paths": {"case": str(tmp_path), "exports": str(tmp_path / "exports"), "reports": str(tmp_path / "reports")},
+            "baseline": {},
+            "parsed": {"links": [], "scripts": [], "forms": []},
+            "evidence": [],
+            "dead_ends": [],
+        },
+    )
+
+    result = ctf_autopilot.run_round(
+        manifest_path,
+        max_actions=2,
+        execute=False,
+        budget_seconds=86400,
+        max_rounds=1,
+    )
+
+    updated = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert result["selected_action_count"] == 2
+    assert updated["autopilot"]["schema"] == "reverselab.ctf_website.autopilot.v1"
+    assert updated["autopilot"]["status"] == "dry_run"
+    assert updated["autopilot"]["rounds"][0]["actions"][0]["execution"]["status"] == "planned"
+    assert updated["next_actions"]
+
+
+def test_run_round_execute_creates_fingerprint_template(tmp_path):
+    manifest_path = tmp_path / "ai_manifest.json"
+    write_manifest(
+        manifest_path,
+        {
+            "schema": "reverselab.ctf_website.ai_manifest.v1",
+            "case": "autopilot-fingerprint",
+            "board": "ctf-website",
+            "target": {"url": "http://example.test/"},
+            "paths": {"case": str(tmp_path), "exports": str(tmp_path / "exports"), "reports": str(tmp_path / "reports")},
+            "baseline": {"headers": {}, "status": 200},
+            "parsed": {"links": ["http://example.test/"], "scripts": [], "forms": []},
+            "evidence": [],
+            "dead_ends": [],
+        },
+    )
+
+    result = ctf_autopilot.run_round(
+        manifest_path,
+        max_actions=1,
+        execute=True,
+        budget_seconds=86400,
+        max_rounds=1,
+    )
+
+    updated = json.loads(manifest_path.read_text(encoding="utf-8"))
+    fingerprint_path = tmp_path / "fingerprints.json"
+    assert fingerprint_path.exists()
+    assert updated["fingerprints"] == str(fingerprint_path)
+    assert updated["evidence"][0]["type"] == "fingerprint_template"
+    assert result["round"]["actions"][0]["execution"]["handler"] == "create_fingerprint_template"

--- a/tests/test_web_ctf_mcp.py
+++ b/tests/test_web_ctf_mcp.py
@@ -67,3 +67,39 @@ def test_run_sqlmap_request_builds_request_args(tmp_path, monkeypatch):
     assert called["tool"] == "sqlmap"
     assert called["args"].endswith('" --batch --dbs')
     assert called["timeout"] == 12
+
+
+def test_ctf_autopilot_round_invokes_controller(tmp_path, monkeypatch):
+    manifest = tmp_path / "ai_manifest.json"
+    manifest.write_text("{}", encoding="utf-8")
+    controller = tmp_path / "ctf_autopilot.py"
+    controller.write_text("# test controller\n", encoding="utf-8")
+    called = {}
+
+    class FakeCompleted:
+        returncode = 0
+        stdout = '{"ok": true}'
+        stderr = ""
+
+    def fake_run(cmd, cwd, capture_output, text, timeout):
+        called.update({"cmd": cmd, "cwd": cwd, "timeout": timeout})
+        return FakeCompleted()
+
+    monkeypatch.setattr(web_ctf, "CTF_AUTOPILOT", controller)
+    monkeypatch.setattr(web_ctf, "ensure_under", lambda path, roots, label: path)
+    monkeypatch.setattr(web_ctf.subprocess, "run", fake_run)
+
+    result = web_ctf.ctf_autopilot_round(
+        str(manifest),
+        max_actions=2,
+        execute=True,
+        allow_network_cve=True,
+        timeout=12,
+    )
+
+    assert result["ok"] is True
+    assert result["exit_code"] == 0
+    assert "--execute" in called["cmd"]
+    assert "--allow-network-cve" in called["cmd"]
+    assert called["cmd"][called["cmd"].index("--max-actions") + 1] == "2"
+    assert called["timeout"] == 60

--- a/tools/ctf-website/AI-USAGE.md
+++ b/tools/ctf-website/AI-USAGE.md
@@ -34,9 +34,10 @@ Web/CTF 目标分析时优先走 MCP：
 
 1. `kb_router(query, board="ctf-website")` 查技术文件。
 2. `ctf_tool_status()` 检查 sqlmap/Burp wrapper 与本地安装状态。
-3. Burp 或浏览器确认请求后，调用 `ctf_save_request(raw_request, case_name, filename)` 保存证据。
-4. SQLi 自动化调用 `run_sqlmap_request(request_path, "--batch ...")`；普通工具调用用 `run_ctf_tool("sqlmap", "...")`。
-5. `burp_status()` 只做无弹窗探测；需要打开 Burp GUI 时才显式调用 `burp_launch(launch=True)`。
+3. 已有 `cases/<case>/ai_manifest.json` 时，可调用 `ctf_autopilot_round(manifest_path, max_actions=4, execute=false)` 做单轮可恢复计划；确认目标授权后再设 `execute=true`。
+4. Burp 或浏览器确认请求后，调用 `ctf_save_request(raw_request, case_name, filename)` 保存证据。
+5. SQLi 自动化调用 `run_sqlmap_request(request_path, "--batch ...")`；普通工具调用用 `run_ctf_tool("sqlmap", "...")`。
+6. `burp_status()` 只做无弹窗探测；需要打开 Burp GUI 时才显式调用 `burp_launch(launch=True)`。
 
 ## 证据输出
 

--- a/tools/skills/mcp/ReverseLabToolsMCP/reverse_lab_tools_mcp.py
+++ b/tools/skills/mcp/ReverseLabToolsMCP/reverse_lab_tools_mcp.py
@@ -1102,6 +1102,18 @@ def ctf_new_challenge(name: str, url: str = "") -> dict[str, Any]:
 
 
 @mcp.tool()
+def ctf_autopilot_round(
+    manifest_path: str,
+    max_actions: int = 4,
+    execute: bool = False,
+    allow_network_cve: bool = False,
+    timeout: int = 600,
+) -> dict[str, Any]:
+    """读取 Web CTF ai_manifest.json，执行一轮带 checkpoint 的 autopilot 计划/allowlist 动作。"""
+    return _safe_call(web_ctf.ctf_autopilot_round, manifest_path, max_actions, execute, allow_network_cve, timeout)
+
+
+@mcp.tool()
 def run_ctf_tool(tool: str, args: str, timeout: int = 120) -> dict[str, Any]:
     """运行 CTF 工具。tool: sqlmap/dirsearch/jwt_tool/tplmap。args: 命令行参数。"""
     return _safe_call(web_ctf.run_ctf_tool, tool, args, timeout)

--- a/tools/skills/mcp/ReverseLabToolsMCP/reverselab_mcp/tools/web_ctf.py
+++ b/tools/skills/mcp/ReverseLabToolsMCP/reverselab_mcp/tools/web_ctf.py
@@ -27,6 +27,7 @@ KB_ROOTS = {
 KB_INDEX = REVERSE_ROOT / "kb" / "ctf-website" / "techniques" / "kb-index.json"
 TECHNIQUES_DIR = REVERSE_ROOT / "kb" / "ctf-website" / "techniques"
 KB_ROUTER = SCRIPTS_DIR / "ctf-website" / "kb_router.py"
+CTF_AUTOPILOT = SCRIPTS_DIR / "ctf-website" / "ctf_autopilot.py"
 CTF_TOOLS_DIR = REVERSE_ROOT / "tools" / "ctf-website"
 CTF_EXPORTS_DIR = REVERSE_ROOT / "exports" / "ctf-website"
 BIN_DIR = REVERSE_ROOT / "tools" / "bin"
@@ -279,6 +280,79 @@ def ctf_new_challenge(name: str, url: str = "") -> dict:
         "url": url,
         "links": str(links.relative_to(REVERSE_ROOT)),
     }
+
+
+def _resolve_manifest_file(manifest_path: str) -> Path:
+    if not manifest_path:
+        raise ValueError("manifest_path is required")
+    resolved = Path(manifest_path).expanduser()
+    if not resolved.is_absolute():
+        resolved = REVERSE_ROOT / resolved
+    resolved = resolved.resolve(strict=True)
+    ensure_under(resolved, [REVERSE_ROOT], "manifest path")
+    if not resolved.is_file():
+        raise ValueError(f"not a file: {resolved}")
+    if resolved.name != "ai_manifest.json":
+        raise ValueError(f"expected ai_manifest.json, got: {resolved}")
+    return resolved
+
+
+def ctf_autopilot_round(
+    manifest_path: str,
+    max_actions: int = 4,
+    execute: bool = False,
+    allow_network_cve: bool = False,
+    timeout: int = 600,
+) -> dict:
+    """Run one stateful Web CTF autopilot round against an ai_manifest.json."""
+    if not CTF_AUTOPILOT.exists():
+        return {"error": f"ctf_autopilot.py not found: {CTF_AUTOPILOT}"}
+    try:
+        resolved = _resolve_manifest_file(manifest_path)
+    except Exception as e:
+        return {"error": str(e)}
+
+    cmd = [
+        sys.executable,
+        str(CTF_AUTOPILOT),
+        str(resolved),
+        "--max-actions",
+        str(max_actions),
+        "--budget-seconds",
+        "1",
+        "--command-timeout",
+        str(timeout),
+    ]
+    if execute:
+        cmd.append("--execute")
+    if allow_network_cve:
+        cmd.append("--allow-network-cve")
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(REVERSE_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=max(timeout + 30, 60),
+        )
+    except subprocess.TimeoutExpired:
+        return {"error": f"timeout after {timeout}s", "manifest": str(resolved)}
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        payload = {
+            "stdout": result.stdout[-8192:],
+            "stderr": result.stderr[-4096:],
+        }
+    payload.update(
+        {
+            "exit_code": result.returncode,
+            "stderr": result.stderr[-4096:],
+        }
+    )
+    return payload
 
 
 # ── CTF Tool Runner ──


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a stateful Web CTF autopilot controller with dry-run, single-round, and loop-capable checkpoint modes.
- Add Claude Code `/ctf-24h` slash command and `.claude/workflows/ctf-24h-round.js` for `/loop + workflow + ai_manifest.json` unattended execution.
- Add `setup_unattended_ctf_runner.py` to generate local `.codex/` and `.claude/settings.local.json` runner profiles for automatic approval/tool permissions.
- Persist checkpoint state, selected actions, and evidence back into `ai_manifest.json`.
- Expose `ctf_autopilot_round` through the ReverseLab MCP web CTF tools.
- Document the 24h workflow and update the Web CTF manifest schema notes.

## Verification
- `python3 -m pytest tests/test_ctf_autopilot.py tests/test_web_ctf_mcp.py -v`
- `node --check .claude/workflows/ctf-24h-round.js`
- `python3 -m py_compile scripts/misc/setup_unattended_ctf_runner.py scripts/ctf-website/ctf_autopilot.py`
- `python3 -m py_compile scripts/ctf-website/ctf_autopilot.py tools/skills/mcp/ReverseLabToolsMCP/reverselab_mcp/tools/web_ctf.py tools/skills/mcp/ReverseLabToolsMCP/reverse_lab_tools_mcp.py`
- `python3 scripts/misc/public_release_check.py` *(fails: latest commit author email is not a noreply address; inherited from current git author configuration)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99985192-7ed5-4b7c-91b1-b5196548e51f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99985192-7ed5-4b7c-91b1-b5196548e51f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new 24-hour, resume-friendly Web/CTF automation flow with loop-based progress tracking and checkpoint recovery.
  * Introduced a single-round CTF autopilot that can plan actions, execute bounded steps, and save progress for later continuation.
  * Added a new command to set up unattended local runner configuration for Claude Code/Codex workflows.

* **Documentation**
  * Expanded usage guides with setup, restart, and execution instructions for long-running CTF runs.

* **Bug Fixes**
  * Improved local configuration handling so machine-specific settings are not committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->