### PR TITLE
docs: add Discord-inspired multi-theme switcher

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -6,6 +6,7 @@
   <title>404 — ReverseLab</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="assets/css/style.css">
+  <script src="assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/404.html
+++ b/docs/404.html
@@ -5,6 +5,34 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>404 — ReverseLab</title>
   <meta name="robots" content="noindex">
+  <script>
+    (function () {
+      try {
+        var key = 'reverselab-theme';
+        var theme = localStorage.getItem(key) || '';
+        var aliases = {
+          light: 'mint-apple', ash: 'dark', midnight: 'midnight-blurple', chroma: 'chroma-glow',
+          grape: 'retro', mocha: 'sepia', onyx: 'under-the-sea', aurora: 'forest'
+        };
+        if (aliases[theme]) theme = aliases[theme];
+        var valid = {
+          cinder:1,'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1,sunset:1,'chroma-glow':1,forest:1,crimson:1,
+          'midnight-blurple':1,mars:1,dusk:1,'under-the-sea':1,retro:1,'neon-nights':1,sepia:1,
+          blurple:1,dark:1
+        };
+        if (!valid[theme]) {
+          theme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'mint-apple';
+        }
+        var light = {
+          'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1
+        };
+        document.documentElement.setAttribute('data-theme', theme);
+        document.documentElement.style.colorScheme = light[theme] ? 'light' : 'dark';
+      } catch (e) {}
+    })();
+  </script>
   <link rel="stylesheet" href="assets/css/style.css">
   <script src="assets/js/theme.js" defer></script>
 </head>

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -1,4 +1,4 @@
-/* ReverseLab Docs ? multi-theme system (Discord-inspired palettes) */
+/* ReverseLab Docs — multi-theme system (Discord-inspired 22-theme swatches) */
 
 :root {
   --bg: #1e1f22;
@@ -13,6 +13,8 @@
   --accent-purple: #c9a7ff;
   --accent-red: #f23f43;
   --code-bg: #111214;
+  --page-gradient: none;
+  --header-tint: color-mix(in srgb, var(--bg-secondary) 88%, transparent);
   --radius: 8px;
   --font-mono: 'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'Consolas', monospace;
   --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans SC', sans-serif;
@@ -23,102 +25,115 @@ html {
   scroll-behavior: smooth;
 }
 
-html[data-theme='dark'] {
+/* 1 Cinder */
+html[data-theme='cinder'] {
   color-scheme: dark;
-  --bg: #1e1f22;
-  --bg-secondary: #2b2d31;
-  --bg-card: #313338;
-  --border: #3f4147;
-  --text: #f2f3f5;
-  --text-muted: #b5bac1;
-  --accent: #5865f2;
-  --accent-green: #23a559;
-  --accent-orange: #f0b232;
-  --accent-purple: #c9a7ff;
-  --accent-red: #f23f43;
-  --code-bg: #111214;
+  --bg: #241b16;
+  --bg-secondary: #32261f;
+  --bg-card: #3f3128;
+  --border: #5a4638;
+  --text: #f6ebe1;
+  --text-muted: #c4b0a0;
+  --accent: #d6a77a;
+  --accent-green: #86efac;
+  --accent-orange: #f59e0b;
+  --accent-purple: #d8b4fe;
+  --accent-red: #f87171;
+  --code-bg: #1a1410;
+  --page-gradient: linear-gradient(160deg, #2b211c 0%, #4a3428 48%, #1a1410 100%);
 }
 
-html[data-theme='light'] {
+/* 2 Mint Apple */
+html[data-theme='mint-apple'] {
   color-scheme: light;
-  --bg: #ffffff;
-  --bg-secondary: #f2f3f5;
-  --bg-card: #e3e5e8;
-  --border: #d0d4d9;
-  --text: #060607;
-  --text-muted: #4e5058;
-  --accent: #5865f2;
-  --accent-green: #248046;
-  --accent-orange: #a12828;
-  --accent-purple: #8757c5;
-  --accent-red: #da373c;
-  --code-bg: #f2f3f5;
+  --bg: #e9fbf2;
+  --bg-secondary: #d7f5e7;
+  --bg-card: #c5eed9;
+  --border: #9ed9ba;
+  --text: #123528;
+  --text-muted: #3f6b57;
+  --accent: #18a56b;
+  --accent-green: #0f8f5a;
+  --accent-orange: #d97706;
+  --accent-purple: #7c3aed;
+  --accent-red: #dc2626;
+  --code-bg: #f3fcf7;
+  --page-gradient: linear-gradient(160deg, #f3fff8 0%, #c9f3df 45%, #9fe3c4 100%);
 }
 
-html[data-theme='ash'] {
-  color-scheme: dark;
-  --bg: #111214;
-  --bg-secondary: #1e1f22;
-  --bg-card: #2b2d31;
-  --border: #3a3c41;
-  --text: #dbdee1;
-  --text-muted: #949ba4;
-  --accent: #5865f2;
-  --accent-green: #23a559;
-  --accent-orange: #f0b232;
-  --accent-purple: #b197fc;
-  --accent-red: #f23f43;
-  --code-bg: #0c0d0e;
+/* 3 Citrus Sherbert */
+html[data-theme='citrus-sherbert'] {
+  color-scheme: light;
+  --bg: #fff3e4;
+  --bg-secondary: #ffe4c4;
+  --bg-card: #ffd3a3;
+  --border: #f0b57a;
+  --text: #4a2a12;
+  --text-muted: #8a5a30;
+  --accent: #ef6c2f;
+  --accent-green: #16a34a;
+  --accent-orange: #ea580c;
+  --accent-purple: #a855f7;
+  --accent-red: #dc2626;
+  --code-bg: #fff8ef;
+  --page-gradient: linear-gradient(160deg, #fff7ec 0%, #ffd9a8 50%, #ffb07a 100%);
 }
 
-html[data-theme='midnight'] {
-  color-scheme: dark;
-  --bg: #000000;
-  --bg-secondary: #0c0d0e;
-  --bg-card: #16171a;
-  --border: #2b2d31;
-  --text: #f2f3f5;
-  --text-muted: #949ba4;
-  --accent: #5865f2;
-  --accent-green: #23a559;
-  --accent-orange: #f0b232;
-  --accent-purple: #c9a7ff;
-  --accent-red: #f23f43;
-  --code-bg: #050505;
+/* 4 Retro Raincloud */
+html[data-theme='retro-raincloud'] {
+  color-scheme: light;
+  --bg: #eef1ff;
+  --bg-secondary: #e0e4ff;
+  --bg-card: #d2d8ff;
+  --border: #b4bdf5;
+  --text: #1e1b4b;
+  --text-muted: #4c4a7a;
+  --accent: #6d5efc;
+  --accent-green: #16a34a;
+  --accent-orange: #ea580c;
+  --accent-purple: #9333ea;
+  --accent-red: #e11d48;
+  --code-bg: #f7f8ff;
+  --page-gradient: linear-gradient(160deg, #f4f6ff 0%, #d6c4ff 48%, #f0b7ff 100%);
 }
 
-html[data-theme='chroma'] {
-  color-scheme: dark;
-  --bg: #0d1b1a;
-  --bg-secondary: #132826;
-  --bg-card: #1a3531;
-  --border: #2d4f49;
-  --text: #e8fff8;
-  --text-muted: #9dcdc1;
-  --accent: #5eead4;
-  --accent-green: #86efac;
-  --accent-orange: #fcd34d;
-  --accent-purple: #c084fc;
-  --accent-red: #fb7185;
-  --code-bg: #0a1514;
+/* 5 Hanami */
+html[data-theme='hanami'] {
+  color-scheme: light;
+  --bg: #fff0f5;
+  --bg-secondary: #ffe1ec;
+  --bg-card: #ffd0e2;
+  --border: #f2aec8;
+  --text: #4a1830;
+  --text-muted: #8a4a64;
+  --accent: #e85a9a;
+  --accent-green: #16a34a;
+  --accent-orange: #ea580c;
+  --accent-purple: #c026d3;
+  --accent-red: #e11d48;
+  --code-bg: #fff7fa;
+  --page-gradient: linear-gradient(160deg, #fff7fb 0%, #ffd0e4 48%, #ffb7d5 100%);
 }
 
-html[data-theme='dusk'] {
-  color-scheme: dark;
-  --bg: #1a1024;
-  --bg-secondary: #261536;
-  --bg-card: #342148;
-  --border: #4d3168;
-  --text: #f5e9ff;
-  --text-muted: #c4a8e0;
-  --accent: #c084fc;
-  --accent-green: #86efac;
-  --accent-orange: #fbbf24;
-  --accent-purple: #e9d5ff;
-  --accent-red: #fb7185;
-  --code-bg: #140c1d;
+/* 6 Sunrise */
+html[data-theme='sunrise'] {
+  color-scheme: light;
+  --bg: #fff6e5;
+  --bg-secondary: #ffebc4;
+  --bg-card: #ffdf9e;
+  --border: #f0c56e;
+  --text: #4a3208;
+  --text-muted: #8a6420;
+  --accent: #e39b12;
+  --accent-green: #16a34a;
+  --accent-orange: #d97706;
+  --accent-purple: #a855f7;
+  --accent-red: #dc2626;
+  --code-bg: #fffaf0;
+  --page-gradient: linear-gradient(160deg, #fffaf0 0%, #ffe0a8 50%, #ffc978 100%);
 }
 
+/* 7 Cotton Candy */
 html[data-theme='cotton-candy'] {
   color-scheme: light;
   --bg: #fff5fb;
@@ -133,14 +148,52 @@ html[data-theme='cotton-candy'] {
   --accent-purple: #a855f7;
   --accent-red: #ef4444;
   --code-bg: #fff0f8;
+  --page-gradient: linear-gradient(160deg, #fff8fc 0%, #ffd0f0 48%, #ffb6e8 100%);
 }
 
+/* 8 LoFi */
+html[data-theme='lofi'] {
+  color-scheme: light;
+  --bg: #eef8ff;
+  --bg-secondary: #dcefff;
+  --bg-card: #cbe5ff;
+  --border: #a8ccee;
+  --text: #16324d;
+  --text-muted: #4a6d8a;
+  --accent: #3b82f6;
+  --accent-green: #16a34a;
+  --accent-orange: #ea580c;
+  --accent-purple: #7c3aed;
+  --accent-red: #dc2626;
+  --code-bg: #f5fbff;
+  --page-gradient: linear-gradient(160deg, #f5fbff 0%, #d7ecff 48%, #c7e0ff 100%);
+}
+
+/* 9 Desert Khaki */
+html[data-theme='desert-khaki'] {
+  color-scheme: light;
+  --bg: #f5efdf;
+  --bg-secondary: #ebe1c8;
+  --bg-card: #dfd1ad;
+  --border: #c8b58a;
+  --text: #3f3420;
+  --text-muted: #6f6248;
+  --accent: #a67c3d;
+  --accent-green: #4d7c0f;
+  --accent-orange: #b45309;
+  --accent-purple: #7c3aed;
+  --accent-red: #b91c1c;
+  --code-bg: #faf6ec;
+  --page-gradient: linear-gradient(160deg, #faf6ec 0%, #e7d9b8 50%, #d6c49a 100%);
+}
+
+/* 10 Sunset */
 html[data-theme='sunset'] {
   color-scheme: dark;
-  --bg: #1d1010;
-  --bg-secondary: #2a1515;
-  --bg-card: #3a1d1a;
-  --border: #5a2d27;
+  --bg: #2a1424;
+  --bg-secondary: #3a1c30;
+  --bg-card: #4a253c;
+  --border: #6b3654;
   --text: #ffe8df;
   --text-muted: #d2a194;
   --accent: #fb7185;
@@ -148,9 +201,29 @@ html[data-theme='sunset'] {
   --accent-orange: #fb923c;
   --accent-purple: #f0abfc;
   --accent-red: #ef4444;
-  --code-bg: #150b0b;
+  --code-bg: #1d0e18;
+  --page-gradient: linear-gradient(160deg, #3a1830 0%, #7a2f4d 42%, #c45b3c 100%);
 }
 
+/* 11 Chroma Glow */
+html[data-theme='chroma-glow'] {
+  color-scheme: dark;
+  --bg: #120f2b;
+  --bg-secondary: #1a1740;
+  --bg-card: #24205a;
+  --border: #3a3480;
+  --text: #e8f7ff;
+  --text-muted: #a8c4e0;
+  --accent: #38bdf8;
+  --accent-green: #4ade80;
+  --accent-orange: #fbbf24;
+  --accent-purple: #a78bfa;
+  --accent-red: #fb7185;
+  --code-bg: #0d0b22;
+  --page-gradient: linear-gradient(160deg, #1a0f3d 0%, #2b1f7a 35%, #1f6bff 70%, #0e7490 100%);
+}
+
+/* 12 Forest */
 html[data-theme='forest'] {
   color-scheme: dark;
   --bg: #0f1712;
@@ -165,8 +238,10 @@ html[data-theme='forest'] {
   --accent-purple: #a3e635;
   --accent-red: #f87171;
   --code-bg: #0b120e;
+  --page-gradient: linear-gradient(160deg, #0f1a12 0%, #1a3320 48%, #2f5d3a 100%);
 }
 
+/* 13 Crimson Moon */
 html[data-theme='crimson'] {
   color-scheme: dark;
   --bg: #1a0c10;
@@ -181,30 +256,124 @@ html[data-theme='crimson'] {
   --accent-purple: #e879f9;
   --accent-red: #fb7185;
   --code-bg: #12080c;
+  --page-gradient: linear-gradient(160deg, #1a0a0c 0%, #3a1018 48%, #6b1824 100%);
 }
 
-html[data-theme='grape'] {
+/* 14 Midnight Blurple */
+html[data-theme='midnight-blurple'] {
   color-scheme: dark;
-  --bg: #14122b;
-  --bg-secondary: #1c1a3a;
-  --bg-card: #26224d;
-  --border: #3a3470;
-  --text: #ebe8ff;
-  --text-muted: #b3add9;
-  --accent: #818cf8;
+  --bg: #0b0c1a;
+  --bg-secondary: #14162b;
+  --bg-card: #1d2040;
+  --border: #2f3360;
+  --text: #e8eaff;
+  --text-muted: #a0a6d0;
+  --accent: #7289da;
+  --accent-green: #23a559;
+  --accent-orange: #f0b232;
+  --accent-purple: #b197fc;
+  --accent-red: #f23f43;
+  --code-bg: #080912;
+  --page-gradient: linear-gradient(160deg, #080914 0%, #1a1b3a 48%, #2b2d6b 100%);
+}
+
+/* 15 Mars */
+html[data-theme='mars'] {
+  color-scheme: dark;
+  --bg: #1a100c;
+  --bg-secondary: #2a1a14;
+  --bg-card: #3a241c;
+  --border: #5a382c;
+  --text: #ffe8df;
+  --text-muted: #d2a894;
+  --accent: #e07a4a;
+  --accent-green: #86efac;
+  --accent-orange: #fb923c;
+  --accent-purple: #f0abfc;
+  --accent-red: #ef4444;
+  --code-bg: #120b08;
+  --page-gradient: linear-gradient(160deg, #1a100c 0%, #3a2218 48%, #6b3a24 100%);
+}
+
+/* 16 Dusk */
+html[data-theme='dusk'] {
+  color-scheme: dark;
+  --bg: #1a1528;
+  --bg-secondary: #241d36;
+  --bg-card: #302848;
+  --border: #463a68;
+  --text: #f5e9ff;
+  --text-muted: #c4a8e0;
+  --accent: #c084fc;
+  --accent-green: #86efac;
+  --accent-orange: #fbbf24;
+  --accent-purple: #e9d5ff;
+  --accent-red: #fb7185;
+  --code-bg: #120e1d;
+  --page-gradient: linear-gradient(160deg, #1a1528 0%, #2a2040 45%, #3d2f5c 100%);
+}
+
+/* 17 Under the Sea */
+html[data-theme='under-the-sea'] {
+  color-scheme: dark;
+  --bg: #0a1a1c;
+  --bg-secondary: #12282c;
+  --bg-card: #18363c;
+  --border: #2a525a;
+  --text: #dcf7f8;
+  --text-muted: #8fb8bc;
+  --accent: #2dd4bf;
   --accent-green: #34d399;
   --accent-orange: #fbbf24;
-  --accent-purple: #c4b5fd;
+  --accent-purple: #a78bfa;
   --accent-red: #f87171;
-  --code-bg: #100e22;
+  --code-bg: #071214;
+  --page-gradient: linear-gradient(160deg, #0a1a1c 0%, #12333a 48%, #1a4d55 100%);
 }
 
-html[data-theme='mocha'] {
+/* 18 Retro */
+html[data-theme='retro'] {
   color-scheme: dark;
-  --bg: #1a1410;
-  --bg-secondary: #261d17;
-  --bg-card: #33271e;
-  --border: #4a3a2e;
+  --bg: #1a1230;
+  --bg-secondary: #261840;
+  --bg-card: #342055;
+  --border: #4e317a;
+  --text: #f3e8ff;
+  --text-muted: #c4a8e8;
+  --accent: #c084fc;
+  --accent-green: #4ade80;
+  --accent-orange: #fbbf24;
+  --accent-purple: #e879f9;
+  --accent-red: #fb7185;
+  --code-bg: #120c22;
+  --page-gradient: linear-gradient(160deg, #1a1230 0%, #3a2060 42%, #6b3aa0 78%, #2a1040 100%);
+}
+
+/* 19 Neon Nights */
+html[data-theme='neon-nights'] {
+  color-scheme: dark;
+  --bg: #0d1020;
+  --bg-secondary: #161a35;
+  --bg-card: #1f2448;
+  --border: #343a70;
+  --text: #f0e9ff;
+  --text-muted: #b0a8d8;
+  --accent: #ff4fd8;
+  --accent-green: #4ade80;
+  --accent-orange: #fbbf24;
+  --accent-purple: #a78bfa;
+  --accent-red: #fb7185;
+  --code-bg: #090c18;
+  --page-gradient: linear-gradient(160deg, #0d1020 0%, #1a1840 35%, #3a2080 70%, #5b1a60 100%);
+}
+
+/* 20 Sepia */
+html[data-theme='sepia'] {
+  color-scheme: dark;
+  --bg: #241c14;
+  --bg-secondary: #32271c;
+  --bg-card: #403224;
+  --border: #5a4834;
   --text: #f6ebe1;
   --text-muted: #c4b0a0;
   --accent: #d6a77a;
@@ -212,52 +381,68 @@ html[data-theme='mocha'] {
   --accent-orange: #f59e0b;
   --accent-purple: #d8b4fe;
   --accent-red: #f87171;
-  --code-bg: #120e0b;
+  --code-bg: #1a1410;
+  --page-gradient: linear-gradient(160deg, #2a2014 0%, #4a3820 55%, #1a1410 100%);
 }
 
-html[data-theme='onyx'] {
+/* 21 Blurple */
+html[data-theme='blurple'] {
   color-scheme: dark;
-  --bg: #0f141b;
-  --bg-secondary: #171e28;
-  --bg-card: #1f2937;
-  --border: #334155;
-  --text: #e5eefc;
-  --text-muted: #94a3b8;
-  --accent: #60a5fa;
-  --accent-green: #34d399;
+  --bg: #2b2d6b;
+  --bg-secondary: #34378a;
+  --bg-card: #3f44a8;
+  --border: #5a60c8;
+  --text: #eef0ff;
+  --text-muted: #c5c9f5;
+  --accent: #a5b4fc;
+  --accent-green: #4ade80;
   --accent-orange: #fbbf24;
-  --accent-purple: #a78bfa;
-  --accent-red: #f87171;
-  --code-bg: #0b1016;
-}
-
-html[data-theme='aurora'] {
-  color-scheme: dark;
-  --bg: #06130f;
-  --bg-secondary: #0d1d18;
-  --bg-card: #12261f;
-  --border: #234136;
-  --text: #ddf8ef;
-  --text-muted: #92b6ab;
-  --accent: #5eead4;
-  --accent-green: #86efac;
-  --accent-orange: #fcd34d;
-  --accent-purple: #c084fc;
+  --accent-purple: #ddd6fe;
   --accent-red: #fb7185;
-  --code-bg: #0d1b17;
+  --code-bg: #1f2155;
+  --page-gradient: linear-gradient(160deg, #2b2d6b 0%, #3b3f9a 48%, #5865f2 100%);
 }
 
+/* 22 Dark (classic Discord) */
+html[data-theme='dark'] {
+  color-scheme: dark;
+  --bg: #1e1f22;
+  --bg-secondary: #2b2d31;
+  --bg-card: #313338;
+  --border: #3f4147;
+  --text: #f2f3f5;
+  --text-muted: #b5bac1;
+  --accent: #5865f2;
+  --accent-green: #23a559;
+  --accent-orange: #f0b232;
+  --accent-purple: #c9a7ff;
+  --accent-red: #f23f43;
+  --code-bg: #111214;
+  --page-gradient: linear-gradient(160deg, #1e1f22 0%, #2b2d31 55%, #1a1b1e 100%);
+}
+
+/* legacy aliases still render if old HTML/data-theme remains */
+html[data-theme='light'] { color-scheme: light; --bg:#ffffff; --bg-secondary:#f2f3f5; --bg-card:#e3e5e8; --border:#d0d4d9; --text:#060607; --text-muted:#4e5058; --accent:#5865f2; --accent-green:#248046; --accent-orange:#a12828; --accent-purple:#8757c5; --accent-red:#da373c; --code-bg:#f2f3f5; --page-gradient:none; }
+html[data-theme='ash'] { color-scheme: dark; --bg:#111214; --bg-secondary:#1e1f22; --bg-card:#2b2d31; --border:#3a3c41; --text:#dbdee1; --text-muted:#949ba4; --accent:#5865f2; --accent-green:#23a559; --accent-orange:#f0b232; --accent-purple:#b197fc; --accent-red:#f23f43; --code-bg:#0c0d0e; --page-gradient:none; }
+html[data-theme='midnight'] { color-scheme: dark; --bg:#000000; --bg-secondary:#0c0d0e; --bg-card:#16171a; --border:#2b2d31; --text:#f2f3f5; --text-muted:#949ba4; --accent:#5865f2; --accent-green:#23a559; --accent-orange:#f0b232; --accent-purple:#c9a7ff; --accent-red:#f23f43; --code-bg:#050505; --page-gradient:none; }
+html[data-theme='chroma'] { color-scheme: dark; --bg:#0d1b1a; --bg-secondary:#132826; --bg-card:#1a3531; --border:#2d4f49; --text:#e8fff8; --text-muted:#9dcdc1; --accent:#5eead4; --accent-green:#86efac; --accent-orange:#fcd34d; --accent-purple:#c084fc; --accent-red:#fb7185; --code-bg:#0a1514; --page-gradient:none; }
+html[data-theme='grape'] { color-scheme: dark; --bg:#14122b; --bg-secondary:#1c1a3a; --bg-card:#26224d; --border:#3a3470; --text:#ebe8ff; --text-muted:#b3add9; --accent:#818cf8; --accent-green:#34d399; --accent-orange:#fbbf24; --accent-purple:#c4b5fd; --accent-red:#f87171; --code-bg:#100e22; --page-gradient:none; }
+html[data-theme='mocha'] { color-scheme: dark; --bg:#1a1410; --bg-secondary:#261d17; --bg-card:#33271e; --border:#4a3a2e; --text:#f6ebe1; --text-muted:#c4b0a0; --accent:#d6a77a; --accent-green:#86efac; --accent-orange:#f59e0b; --accent-purple:#d8b4fe; --accent-red:#f87171; --code-bg:#120e0b; --page-gradient:none; }
+html[data-theme='onyx'] { color-scheme: dark; --bg:#0f141b; --bg-secondary:#171e28; --bg-card:#1f2937; --border:#334155; --text:#e5eefc; --text-muted:#94a3b8; --accent:#60a5fa; --accent-green:#34d399; --accent-orange:#fbbf24; --accent-purple:#a78bfa; --accent-red:#f87171; --code-bg:#0b1016; --page-gradient:none; }
+html[data-theme='aurora'] { color-scheme: dark; --bg:#06130f; --bg-secondary:#0d1d18; --bg-card:#12261f; --border:#234136; --text:#ddf8ef; --text-muted:#92b6ab; --accent:#5eead4; --accent-green:#86efac; --accent-orange:#fcd34d; --accent-purple:#c084fc; --accent-red:#fb7185; --code-bg:#0d1b17; --page-gradient:none; }
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
 body {
-  background: var(--bg);
+  background-color: var(--bg);
+  background-image: var(--page-gradient);
+  background-attachment: fixed;
   color: var(--text);
   font-family: var(--font-sans);
   line-height: 1.6;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  transition: background-color 0.2s ease, color 0.2s ease;
+  transition: background-color 0.2s ease, background-image 0.25s ease, color 0.2s ease;
 }
 
 a { color: var(--accent); text-decoration: none; }
@@ -321,41 +506,154 @@ code, pre { font-family: var(--font-mono); }
 }
 
 .theme-switcher {
+  position: relative;
   display: flex;
   align-items: center;
   margin-left: auto;
+  z-index: 40;
 }
 
-.theme-select {
-  appearance: none;
-  -webkit-appearance: none;
-  background: var(--bg-card);
-  color: var(--text);
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   border: 1px solid var(--border);
-  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--bg-card) 88%, transparent);
+  color: var(--text);
+  border-radius: 999px;
+  padding: 6px 12px 6px 8px;
   font: inherit;
   font-size: 13px;
-  line-height: 1.2;
-  padding: 7px 34px 7px 12px;
-  min-width: 150px;
   cursor: pointer;
-  transition: border-color 0.15s, background-color 0.15s, color 0.15s, box-shadow 0.15s;
-  background-image: linear-gradient(45deg, transparent 50%, var(--text-muted) 50%), linear-gradient(135deg, var(--text-muted) 50%, transparent 50%);
-  background-position: calc(100% - 18px) calc(1em + 1px), calc(100% - 12px) calc(1em + 1px);
-  background-size: 6px 6px, 6px 6px;
-  background-repeat: no-repeat;
+  transition: border-color 0.15s, box-shadow 0.15s, background-color 0.15s;
+  backdrop-filter: blur(8px);
 }
 
-.theme-select:hover { border-color: var(--accent); }
-.theme-select:focus {
+.theme-toggle:hover {
+  border-color: var(--accent);
+}
+
+.theme-toggle:focus-visible {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 28%, transparent);
 }
-.theme-select option {
-  background: var(--bg-secondary);
-  color: var(--text);
+
+.theme-toggle-swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  border: 1px solid color-mix(in srgb, #000 18%, transparent);
+  background: linear-gradient(135deg, #1e1f22, #5865f2);
+  flex: 0 0 auto;
 }
+
+.theme-toggle-text {
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.theme-toggle-text [data-theme-current] {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.theme-toggle-caret {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.theme-panel {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(320px, calc(100vw - 32px));
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg-secondary) 92%, transparent);
+  box-shadow: 0 18px 48px color-mix(in srgb, #000 35%, transparent);
+  backdrop-filter: blur(14px);
+}
+
+.theme-panel[hidden] { display: none !important; }
+
+.theme-panel-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+.theme-panel-hint {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: 12px;
+}
+
+.theme-swatch-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.theme-swatch {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 14px;
+  border: 2px solid color-mix(in srgb, #fff 18%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, #000 12%, transparent);
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease;
+}
+
+.theme-swatch:hover {
+  transform: translateY(-1px) scale(1.02);
+  border-color: color-mix(in srgb, var(--accent) 70%, #fff 30%);
+}
+
+.theme-swatch:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
+.theme-swatch.is-active {
+  border-color: #fff;
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, var(--accent) 80%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, #000 18%, transparent);
+}
+
+.theme-swatch-check {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  font-size: 12px;
+  font-weight: 700;
+  color: #111;
+  background: #fff;
+  opacity: 0;
+  transform: scale(0.8);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+}
+
+.theme-swatch.is-active .theme-swatch-check {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.site-header {
+  background: color-mix(in srgb, var(--bg-secondary) 86%, transparent);
+  backdrop-filter: blur(10px);
+}
+
 
 main { flex: 1; padding: 40px 0; }
 
@@ -577,6 +875,8 @@ main { flex: 1; padding: 40px 0; }
   .tool-families { grid-template-columns: 1fr; }
   .tool-grid { grid-template-columns: 1fr; }
   .site-header .container { align-items: flex-start; }
-  .theme-switcher { margin-left: 0; width: 100%; }
-  .theme-select { width: 100%; min-width: 0; }
+  .theme-switcher { margin-left: 0; width: 100%; justify-content: flex-start; }
+  .theme-toggle { width: 100%; justify-content: space-between; }
+  .theme-panel { left: 0; right: auto; width: min(340px, calc(100vw - 32px)); }
 }
+

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -1,21 +1,250 @@
-/* ReverseLab Docs — Terminal-inspired dark theme */
+/* ReverseLab Docs ? multi-theme system (Discord-inspired palettes) */
 
 :root {
-  --bg: #0d1117;
-  --bg-secondary: #161b22;
-  --bg-card: #21262d;
-  --border: #30363d;
-  --text: #c9d1d9;
-  --text-muted: #8b949e;
-  --accent: #58a6ff;
-  --accent-green: #3fb950;
-  --accent-orange: #d29922;
-  --accent-purple: #a371f7;
-  --accent-red: #f85149;
-  --code-bg: #1c2128;
+  --bg: #1e1f22;
+  --bg-secondary: #2b2d31;
+  --bg-card: #313338;
+  --border: #3f4147;
+  --text: #f2f3f5;
+  --text-muted: #b5bac1;
+  --accent: #5865f2;
+  --accent-green: #23a559;
+  --accent-orange: #f0b232;
+  --accent-purple: #c9a7ff;
+  --accent-red: #f23f43;
+  --code-bg: #111214;
   --radius: 8px;
   --font-mono: 'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'Consolas', monospace;
   --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans SC', sans-serif;
+}
+
+html {
+  color-scheme: dark;
+  scroll-behavior: smooth;
+}
+
+html[data-theme='dark'] {
+  color-scheme: dark;
+  --bg: #1e1f22;
+  --bg-secondary: #2b2d31;
+  --bg-card: #313338;
+  --border: #3f4147;
+  --text: #f2f3f5;
+  --text-muted: #b5bac1;
+  --accent: #5865f2;
+  --accent-green: #23a559;
+  --accent-orange: #f0b232;
+  --accent-purple: #c9a7ff;
+  --accent-red: #f23f43;
+  --code-bg: #111214;
+}
+
+html[data-theme='light'] {
+  color-scheme: light;
+  --bg: #ffffff;
+  --bg-secondary: #f2f3f5;
+  --bg-card: #e3e5e8;
+  --border: #d0d4d9;
+  --text: #060607;
+  --text-muted: #4e5058;
+  --accent: #5865f2;
+  --accent-green: #248046;
+  --accent-orange: #a12828;
+  --accent-purple: #8757c5;
+  --accent-red: #da373c;
+  --code-bg: #f2f3f5;
+}
+
+html[data-theme='ash'] {
+  color-scheme: dark;
+  --bg: #111214;
+  --bg-secondary: #1e1f22;
+  --bg-card: #2b2d31;
+  --border: #3a3c41;
+  --text: #dbdee1;
+  --text-muted: #949ba4;
+  --accent: #5865f2;
+  --accent-green: #23a559;
+  --accent-orange: #f0b232;
+  --accent-purple: #b197fc;
+  --accent-red: #f23f43;
+  --code-bg: #0c0d0e;
+}
+
+html[data-theme='midnight'] {
+  color-scheme: dark;
+  --bg: #000000;
+  --bg-secondary: #0c0d0e;
+  --bg-card: #16171a;
+  --border: #2b2d31;
+  --text: #f2f3f5;
+  --text-muted: #949ba4;
+  --accent: #5865f2;
+  --accent-green: #23a559;
+  --accent-orange: #f0b232;
+  --accent-purple: #c9a7ff;
+  --accent-red: #f23f43;
+  --code-bg: #050505;
+}
+
+html[data-theme='chroma'] {
+  color-scheme: dark;
+  --bg: #0d1b1a;
+  --bg-secondary: #132826;
+  --bg-card: #1a3531;
+  --border: #2d4f49;
+  --text: #e8fff8;
+  --text-muted: #9dcdc1;
+  --accent: #5eead4;
+  --accent-green: #86efac;
+  --accent-orange: #fcd34d;
+  --accent-purple: #c084fc;
+  --accent-red: #fb7185;
+  --code-bg: #0a1514;
+}
+
+html[data-theme='dusk'] {
+  color-scheme: dark;
+  --bg: #1a1024;
+  --bg-secondary: #261536;
+  --bg-card: #342148;
+  --border: #4d3168;
+  --text: #f5e9ff;
+  --text-muted: #c4a8e0;
+  --accent: #c084fc;
+  --accent-green: #86efac;
+  --accent-orange: #fbbf24;
+  --accent-purple: #e9d5ff;
+  --accent-red: #fb7185;
+  --code-bg: #140c1d;
+}
+
+html[data-theme='cotton-candy'] {
+  color-scheme: light;
+  --bg: #fff5fb;
+  --bg-secondary: #ffe8f5;
+  --bg-card: #ffd6ef;
+  --border: #f3b6d8;
+  --text: #4a1840;
+  --text-muted: #8a4a74;
+  --accent: #ec4899;
+  --accent-green: #10b981;
+  --accent-orange: #f59e0b;
+  --accent-purple: #a855f7;
+  --accent-red: #ef4444;
+  --code-bg: #fff0f8;
+}
+
+html[data-theme='sunset'] {
+  color-scheme: dark;
+  --bg: #1d1010;
+  --bg-secondary: #2a1515;
+  --bg-card: #3a1d1a;
+  --border: #5a2d27;
+  --text: #ffe8df;
+  --text-muted: #d2a194;
+  --accent: #fb7185;
+  --accent-green: #86efac;
+  --accent-orange: #fb923c;
+  --accent-purple: #f0abfc;
+  --accent-red: #ef4444;
+  --code-bg: #150b0b;
+}
+
+html[data-theme='forest'] {
+  color-scheme: dark;
+  --bg: #0f1712;
+  --bg-secondary: #16231b;
+  --bg-card: #1d2e24;
+  --border: #2f4a3a;
+  --text: #e7f6ec;
+  --text-muted: #9fbfab;
+  --accent: #4ade80;
+  --accent-green: #86efac;
+  --accent-orange: #fbbf24;
+  --accent-purple: #a3e635;
+  --accent-red: #f87171;
+  --code-bg: #0b120e;
+}
+
+html[data-theme='crimson'] {
+  color-scheme: dark;
+  --bg: #1a0c10;
+  --bg-secondary: #271018;
+  --bg-card: #351520;
+  --border: #552433;
+  --text: #ffe7ee;
+  --text-muted: #d7a0b0;
+  --accent: #f43f5e;
+  --accent-green: #4ade80;
+  --accent-orange: #fb923c;
+  --accent-purple: #e879f9;
+  --accent-red: #fb7185;
+  --code-bg: #12080c;
+}
+
+html[data-theme='grape'] {
+  color-scheme: dark;
+  --bg: #14122b;
+  --bg-secondary: #1c1a3a;
+  --bg-card: #26224d;
+  --border: #3a3470;
+  --text: #ebe8ff;
+  --text-muted: #b3add9;
+  --accent: #818cf8;
+  --accent-green: #34d399;
+  --accent-orange: #fbbf24;
+  --accent-purple: #c4b5fd;
+  --accent-red: #f87171;
+  --code-bg: #100e22;
+}
+
+html[data-theme='mocha'] {
+  color-scheme: dark;
+  --bg: #1a1410;
+  --bg-secondary: #261d17;
+  --bg-card: #33271e;
+  --border: #4a3a2e;
+  --text: #f6ebe1;
+  --text-muted: #c4b0a0;
+  --accent: #d6a77a;
+  --accent-green: #86efac;
+  --accent-orange: #f59e0b;
+  --accent-purple: #d8b4fe;
+  --accent-red: #f87171;
+  --code-bg: #120e0b;
+}
+
+html[data-theme='onyx'] {
+  color-scheme: dark;
+  --bg: #0f141b;
+  --bg-secondary: #171e28;
+  --bg-card: #1f2937;
+  --border: #334155;
+  --text: #e5eefc;
+  --text-muted: #94a3b8;
+  --accent: #60a5fa;
+  --accent-green: #34d399;
+  --accent-orange: #fbbf24;
+  --accent-purple: #a78bfa;
+  --accent-red: #f87171;
+  --code-bg: #0b1016;
+}
+
+html[data-theme='aurora'] {
+  color-scheme: dark;
+  --bg: #06130f;
+  --bg-secondary: #0d1d18;
+  --bg-card: #12261f;
+  --border: #234136;
+  --text: #ddf8ef;
+  --text-muted: #92b6ab;
+  --accent: #5eead4;
+  --accent-green: #86efac;
+  --accent-orange: #fcd34d;
+  --accent-purple: #c084fc;
+  --accent-red: #fb7185;
+  --code-bg: #0d1b17;
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -28,6 +257,7 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 a { color: var(--accent); text-decoration: none; }
@@ -35,8 +265,18 @@ a:hover { text-decoration: underline; }
 code, pre { font-family: var(--font-mono); }
 
 .container { max-width: 1100px; margin: 0 auto; padding: 0 24px; }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 
-/* Header */
 .site-header {
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border);
@@ -80,10 +320,45 @@ code, pre { font-family: var(--font-mono); }
   text-decoration: none;
 }
 
-/* Main content */
+.theme-switcher {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+}
+
+.theme-select {
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--bg-card);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.2;
+  padding: 7px 34px 7px 12px;
+  min-width: 150px;
+  cursor: pointer;
+  transition: border-color 0.15s, background-color 0.15s, color 0.15s, box-shadow 0.15s;
+  background-image: linear-gradient(45deg, transparent 50%, var(--text-muted) 50%), linear-gradient(135deg, var(--text-muted) 50%, transparent 50%);
+  background-position: calc(100% - 18px) calc(1em + 1px), calc(100% - 12px) calc(1em + 1px);
+  background-size: 6px 6px, 6px 6px;
+  background-repeat: no-repeat;
+}
+
+.theme-select:hover { border-color: var(--accent); }
+.theme-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 28%, transparent);
+}
+.theme-select option {
+  background: var(--bg-secondary);
+  color: var(--text);
+}
+
 main { flex: 1; padding: 40px 0; }
 
-/* Hero */
 .hero {
   text-align: center;
   padding: 40px 0 50px;
@@ -106,7 +381,6 @@ main { flex: 1; padding: 40px 0; }
   flex-wrap: wrap;
 }
 
-/* Buttons */
 .btn-primary, .btn-secondary {
   display: inline-block;
   padding: 12px 28px;
@@ -122,7 +396,7 @@ main { flex: 1; padding: 40px 0; }
   border: 1px solid var(--accent);
 }
 .btn-primary:hover {
-  background: #79c0ff;
+  filter: brightness(1.08);
   text-decoration: none;
 }
 .btn-secondary {
@@ -135,7 +409,6 @@ main { flex: 1; padding: 40px 0; }
   text-decoration: none;
 }
 
-/* Board grid */
 .boards { padding: 20px 0 40px; }
 .boards h2, .mcp-highlight h2, .quickstart h2, .faq-section h2 {
   font-size: 24px;
@@ -169,15 +442,12 @@ main { flex: 1; padding: 40px 0; }
   font-size: 12px;
   color: var(--accent);
   font-family: var(--font-mono);
-  background: rgba(88, 166, 255, 0.1);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
   padding: 3px 10px;
   border-radius: 12px;
 }
 
-/* MCP Highlight */
-.mcp-highlight {
-  padding: 30px 0 40px;
-}
+.mcp-highlight { padding: 30px 0 40px; }
 .tool-families {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
@@ -202,7 +472,6 @@ main { flex: 1; padding: 40px 0; }
   border: 1px solid var(--border);
 }
 
-/* KB listing */
 .kb-list { padding: 20px 0; }
 .kb-category {
   background: var(--bg-card);
@@ -232,14 +501,13 @@ main { flex: 1; padding: 40px 0; }
   color: var(--text);
 }
 .kb-category li a:hover {
-  background: rgba(88, 166, 255, 0.08);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
   border-color: var(--border);
   text-decoration: none;
 }
 .kb-category li a .file-name { color: var(--accent); font-family: var(--font-mono); font-size: 13px; }
 .kb-category li a .file-desc { color: var(--text-muted); font-size: 12px; display: block; }
 
-/* Tool catalog */
 .tool-section { margin-bottom: 32px; }
 .tool-section h3 { font-size: 18px; margin-bottom: 12px; }
 .tool-grid {
@@ -261,7 +529,6 @@ main { flex: 1; padding: 40px 0; }
 }
 .tool-card p { font-size: 13px; color: var(--text-muted); }
 
-/* FAQ */
 .faq-list { max-width: 800px; }
 .faq-item {
   background: var(--bg-card);
@@ -273,7 +540,6 @@ main { flex: 1; padding: 40px 0; }
 .faq-item h3 { font-size: 16px; color: var(--text); margin-bottom: 8px; }
 .faq-item p { font-size: 14px; color: var(--text-muted); }
 
-/* Quickstart */
 .quickstart { padding: 20px 0 40px; }
 .quickstart pre {
   background: var(--bg-card);
@@ -285,7 +551,6 @@ main { flex: 1; padding: 40px 0; }
   line-height: 1.7;
 }
 
-/* Footer */
 .site-footer {
   background: var(--bg-secondary);
   border-top: 1px solid var(--border);
@@ -298,7 +563,6 @@ main { flex: 1; padding: 40px 0; }
 .site-footer a:hover { color: var(--accent); }
 .footer-note { margin-top: 8px; font-size: 12px; }
 
-/* Breadcrumb */
 .breadcrumb {
   font-size: 14px;
   color: var(--text-muted);
@@ -307,10 +571,12 @@ main { flex: 1; padding: 40px 0; }
 .breadcrumb a { color: var(--text-muted); }
 .breadcrumb span { color: var(--text); }
 
-/* Responsive */
 @media (max-width: 768px) {
   .hero h2 { font-size: 24px; }
   .board-grid { grid-template-columns: 1fr; }
   .tool-families { grid-template-columns: 1fr; }
   .tool-grid { grid-template-columns: 1fr; }
+  .site-header .container { align-items: flex-start; }
+  .theme-switcher { margin-left: 0; width: 100%; }
+  .theme-select { width: 100%; min-width: 0; }
 }

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -17,7 +17,7 @@
   --header-tint: color-mix(in srgb, var(--bg-secondary) 88%, transparent);
   --radius: 8px;
   --font-mono: 'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'Consolas', monospace;
-  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans SC', sans-serif;
+  --font-sans: -apple-system, blinkmacsystemfont, 'Segoe UI', 'Noto Sans SC', sans-serif;
 }
 
 html {
@@ -458,6 +458,7 @@ code, pre { font-family: var(--font-mono); }
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/docs/assets/js/theme.js
+++ b/docs/assets/js/theme.js
@@ -1,0 +1,101 @@
+(function () {
+  const STORAGE_KEY = 'reverselab-theme';
+  const LIGHT_THEMES = new Set(['light', 'cotton-candy']);
+  const THEMES = [
+    { value: 'dark', label: 'Discord Dark' },
+    { value: 'light', label: 'Discord Light' },
+    { value: 'ash', label: 'Ash / Darker' },
+    { value: 'midnight', label: 'Midnight' },
+    { value: 'chroma', label: 'Chroma Glow' },
+    { value: 'dusk', label: 'Dusk' },
+    { value: 'cotton-candy', label: 'Cotton Candy' },
+    { value: 'sunset', label: 'Sunset' },
+    { value: 'forest', label: 'Forest' },
+    { value: 'crimson', label: 'Crimson' },
+    { value: 'grape', label: 'Grape' },
+    { value: 'mocha', label: 'Mocha' },
+    { value: 'onyx', label: 'Onyx' },
+    { value: 'aurora', label: 'Aurora' }
+  ];
+
+  const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const defaultTheme = prefersDark ? 'dark' : 'light';
+
+  function normalizeTheme(value) {
+    return THEMES.some((theme) => theme.value === value) ? value : defaultTheme;
+  }
+
+  function getSavedTheme() {
+    try {
+      return window.localStorage.getItem(STORAGE_KEY);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function saveTheme(theme) {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    } catch (error) {
+      // Ignore storage failures; the current page still switches theme.
+    }
+  }
+
+  function applyTheme(theme) {
+    const normalized = normalizeTheme(theme);
+    document.documentElement.setAttribute('data-theme', normalized);
+    document.documentElement.style.colorScheme = LIGHT_THEMES.has(normalized) ? 'light' : 'dark';
+    const select = document.querySelector('[data-theme-select]');
+    if (select) select.value = normalized;
+    return normalized;
+  }
+
+  function createSwitcher() {
+    if (document.querySelector('[data-theme-switcher]')) return;
+
+    const nav = document.querySelector('.main-nav');
+    const headerContainer = document.querySelector('.site-header .container');
+    const host = nav || headerContainer;
+    if (!host) return;
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'theme-switcher';
+    wrapper.setAttribute('data-theme-switcher', '');
+
+    const label = document.createElement('label');
+    label.className = 'sr-only';
+    label.setAttribute('for', 'theme-select');
+    label.textContent = 'Theme';
+
+    const select = document.createElement('select');
+    select.id = 'theme-select';
+    select.className = 'theme-select';
+    select.setAttribute('data-theme-select', '');
+    select.setAttribute('aria-label', 'Select theme');
+
+    THEMES.forEach((theme) => {
+      const option = document.createElement('option');
+      option.value = theme.value;
+      option.textContent = theme.label;
+      select.appendChild(option);
+    });
+
+    select.addEventListener('change', (event) => {
+      const nextTheme = applyTheme(event.target.value);
+      saveTheme(nextTheme);
+    });
+
+    wrapper.appendChild(label);
+    wrapper.appendChild(select);
+    host.insertAdjacentElement('afterend', wrapper);
+    select.value = document.documentElement.getAttribute('data-theme') || defaultTheme;
+  }
+
+  applyTheme(getSavedTheme());
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', createSwitcher, { once: true });
+  } else {
+    createSwitcher();
+  }
+})();

--- a/docs/assets/js/theme.js
+++ b/docs/assets/js/theme.js
@@ -1,28 +1,60 @@
 (function () {
   const STORAGE_KEY = 'reverselab-theme';
-  const LIGHT_THEMES = new Set(['light', 'cotton-candy']);
+
+  // 22 Discord-like client themes: solids + gradient "nitro-style" swatches.
+  // value is stored in localStorage / data-theme.
   const THEMES = [
-    { value: 'dark', label: 'Discord Dark' },
-    { value: 'light', label: 'Discord Light' },
-    { value: 'ash', label: 'Ash / Darker' },
-    { value: 'midnight', label: 'Midnight' },
-    { value: 'chroma', label: 'Chroma Glow' },
-    { value: 'dusk', label: 'Dusk' },
-    { value: 'cotton-candy', label: 'Cotton Candy' },
-    { value: 'sunset', label: 'Sunset' },
-    { value: 'forest', label: 'Forest' },
-    { value: 'crimson', label: 'Crimson' },
-    { value: 'grape', label: 'Grape' },
-    { value: 'mocha', label: 'Mocha' },
-    { value: 'onyx', label: 'Onyx' },
-    { value: 'aurora', label: 'Aurora' }
+    { value: 'cinder', label: 'Cinder', scheme: 'dark', swatch: 'linear-gradient(135deg, #2b211c 0%, #4a3428 55%, #6b4a34 100%)' },
+    { value: 'mint-apple', label: 'Mint Apple', scheme: 'light', swatch: 'linear-gradient(135deg, #d8f5e8 0%, #9fe3c4 45%, #5ecf9a 100%)' },
+    { value: 'citrus-sherbert', label: 'Citrus Sherbert', scheme: 'light', swatch: 'linear-gradient(135deg, #ffe8c8 0%, #ffc58a 45%, #ff9f6b 100%)' },
+    { value: 'retro-raincloud', label: 'Retro Raincloud', scheme: 'light', swatch: 'linear-gradient(135deg, #c9d7ff 0%, #d6c4ff 40%, #f0b7ff 100%)' },
+    { value: 'hanami', label: 'Hanami', scheme: 'light', swatch: 'linear-gradient(135deg, #ffe3ef 0%, #ffd0e4 40%, #ffb7d5 100%)' },
+    { value: 'sunrise', label: 'Sunrise', scheme: 'light', swatch: 'linear-gradient(135deg, #fff1d6 0%, #ffe0a8 45%, #ffc978 100%)' },
+    { value: 'cotton-candy', label: 'Cotton Candy', scheme: 'light', swatch: 'linear-gradient(135deg, #ffe8f7 0%, #ffd0f0 40%, #ffb6e8 100%)' },
+    { value: 'lofi', label: 'LoFi', scheme: 'light', swatch: 'linear-gradient(135deg, #e8f7ff 0%, #d7ecff 45%, #c7e0ff 100%)' },
+    { value: 'desert-khaki', label: 'Desert Khaki', scheme: 'light', swatch: 'linear-gradient(135deg, #f3ecda 0%, #e7d9b8 50%, #d6c49a 100%)' },
+    { value: 'sunset', label: 'Sunset', scheme: 'dark', swatch: 'linear-gradient(135deg, #4a1d3a 0%, #7a2f4d 40%, #c45b3c 100%)' },
+    { value: 'chroma-glow', label: 'Chroma Glow', scheme: 'dark', swatch: 'linear-gradient(135deg, #1a0f3d 0%, #2b1f7a 35%, #1f6bff 70%, #22d3ee 100%)' },
+    { value: 'forest', label: 'Forest', scheme: 'dark', swatch: 'linear-gradient(135deg, #0f1a12 0%, #1a3320 45%, #2f5d3a 100%)' },
+    { value: 'crimson', label: 'Crimson Moon', scheme: 'dark', swatch: 'linear-gradient(135deg, #1a0a0c 0%, #3a1018 45%, #6b1824 100%)' },
+    { value: 'midnight-blurple', label: 'Midnight Blurple', scheme: 'dark', swatch: 'linear-gradient(135deg, #0b0c1a 0%, #1a1b3a 45%, #2b2d6b 100%)' },
+    { value: 'mars', label: 'Mars', scheme: 'dark', swatch: 'linear-gradient(135deg, #1a100c 0%, #3a2218 45%, #6b3a24 100%)' },
+    { value: 'dusk', label: 'Dusk', scheme: 'dark', swatch: 'linear-gradient(135deg, #1a1528 0%, #2a2040 40%, #3d2f5c 100%)' },
+    { value: 'under-the-sea', label: 'Under the Sea', scheme: 'dark', swatch: 'linear-gradient(135deg, #0a1a1c 0%, #12333a 40%, #1a4d55 100%)' },
+    { value: 'retro', label: 'Retro', scheme: 'dark', swatch: 'linear-gradient(135deg, #1a1230 0%, #3a2060 40%, #6b3aa0 70%, #c45bff 100%)' },
+    { value: 'neon-nights', label: 'Neon Nights', scheme: 'dark', swatch: 'linear-gradient(135deg, #0d1020 0%, #1a1840 35%, #3a2080 65%, #ff4fd8 100%)' },
+    { value: 'sepia', label: 'Sepia', scheme: 'dark', swatch: 'linear-gradient(135deg, #2a2014 0%, #4a3820 50%, #6b5230 100%)' },
+    { value: 'blurple', label: 'Blurple', scheme: 'dark', swatch: 'linear-gradient(135deg, #2b2d6b 0%, #3b3f9a 45%, #5865f2 100%)' },
+    { value: 'dark', label: 'Dark', scheme: 'dark', swatch: 'linear-gradient(135deg, #1e1f22 0%, #2b2d31 55%, #313338 100%)' }
   ];
 
-  const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const defaultTheme = prefersDark ? 'dark' : 'light';
+  // Keep old saved values working after rename.
+  const ALIASES = {
+    light: 'mint-apple',
+    ash: 'dark',
+    midnight: 'midnight-blurple',
+    chroma: 'chroma-glow',
+    grape: 'retro',
+    mocha: 'sepia',
+    onyx: 'under-the-sea',
+    aurora: 'forest',
+    'cotton-candy': 'cotton-candy',
+    sunset: 'sunset',
+    forest: 'forest',
+    crimson: 'crimson',
+    dusk: 'dusk',
+    dark: 'dark'
+  };
 
-  function normalizeTheme(value) {
-    return THEMES.some((theme) => theme.value === value) ? value : defaultTheme;
+  const LIGHT_THEMES = new Set(THEMES.filter((t) => t.scheme === 'light').map((t) => t.value));
+  const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const defaultTheme = prefersDark ? 'dark' : 'mint-apple';
+
+  function resolveTheme(value) {
+    if (!value) return defaultTheme;
+    if (THEMES.some((theme) => theme.value === value)) return value;
+    if (ALIASES[value] && THEMES.some((theme) => theme.value === ALIASES[value])) return ALIASES[value];
+    return defaultTheme;
   }
 
   function getSavedTheme() {
@@ -41,12 +73,30 @@
     }
   }
 
+  function syncSwitcher(theme) {
+    const buttons = document.querySelectorAll('[data-theme-swatch]');
+    buttons.forEach((button) => {
+      const active = button.getAttribute('data-theme-swatch') === theme;
+      button.classList.toggle('is-active', active);
+      button.setAttribute('aria-checked', active ? 'true' : 'false');
+    });
+
+    const label = document.querySelector('[data-theme-current]');
+    if (label) {
+      const found = THEMES.find((item) => item.value === theme);
+      label.textContent = found ? found.label : theme;
+    }
+
+    // legacy select support if present
+    const select = document.querySelector('[data-theme-select]');
+    if (select) select.value = theme;
+  }
+
   function applyTheme(theme) {
-    const normalized = normalizeTheme(theme);
+    const normalized = resolveTheme(theme);
     document.documentElement.setAttribute('data-theme', normalized);
     document.documentElement.style.colorScheme = LIGHT_THEMES.has(normalized) ? 'light' : 'dark';
-    const select = document.querySelector('[data-theme-select]');
-    if (select) select.value = normalized;
+    syncSwitcher(normalized);
     return normalized;
   }
 
@@ -62,35 +112,111 @@
     wrapper.className = 'theme-switcher';
     wrapper.setAttribute('data-theme-switcher', '');
 
-    const label = document.createElement('label');
-    label.className = 'sr-only';
-    label.setAttribute('for', 'theme-select');
-    label.textContent = 'Theme';
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'theme-toggle';
+    toggle.setAttribute('data-theme-toggle', '');
+    toggle.setAttribute('aria-haspopup', 'true');
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.setAttribute('aria-label', 'Open theme picker');
 
-    const select = document.createElement('select');
-    select.id = 'theme-select';
-    select.className = 'theme-select';
-    select.setAttribute('data-theme-select', '');
-    select.setAttribute('aria-label', 'Select theme');
+    const toggleSwatch = document.createElement('span');
+    toggleSwatch.className = 'theme-toggle-swatch';
+    toggleSwatch.setAttribute('data-theme-toggle-swatch', '');
+
+    const toggleText = document.createElement('span');
+    toggleText.className = 'theme-toggle-text';
+    toggleText.innerHTML = '主题 <span data-theme-current></span>';
+
+    const caret = document.createElement('span');
+    caret.className = 'theme-toggle-caret';
+    caret.setAttribute('aria-hidden', 'true');
+    caret.textContent = '▾';
+
+    toggle.appendChild(toggleSwatch);
+    toggle.appendChild(toggleText);
+    toggle.appendChild(caret);
+
+    const panel = document.createElement('div');
+    panel.className = 'theme-panel';
+    panel.setAttribute('data-theme-panel', '');
+    panel.hidden = true;
+
+    const title = document.createElement('div');
+    title.className = 'theme-panel-title';
+    title.textContent = '预览主题';
+
+    const hint = document.createElement('p');
+    hint.className = 'theme-panel-hint';
+    hint.textContent = 'Discord 风格色板 · 点击 swatch 切换';
+
+    const grid = document.createElement('div');
+    grid.className = 'theme-swatch-grid';
+    grid.setAttribute('role', 'radiogroup');
+    grid.setAttribute('aria-label', 'Theme swatches');
 
     THEMES.forEach((theme) => {
-      const option = document.createElement('option');
-      option.value = theme.value;
-      option.textContent = theme.label;
-      select.appendChild(option);
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'theme-swatch';
+      button.setAttribute('data-theme-swatch', theme.value);
+      button.setAttribute('role', 'radio');
+      button.setAttribute('aria-checked', 'false');
+      button.setAttribute('aria-label', theme.label);
+      button.title = theme.label;
+      button.style.background = theme.swatch;
+
+      const check = document.createElement('span');
+      check.className = 'theme-swatch-check';
+      check.setAttribute('aria-hidden', 'true');
+      check.textContent = '✓';
+      button.appendChild(check);
+
+      button.addEventListener('click', () => {
+        const nextTheme = applyTheme(theme.value);
+        saveTheme(nextTheme);
+        const current = THEMES.find((item) => item.value === nextTheme);
+        if (current) toggleSwatch.style.background = current.swatch;
+        // keep panel open like Discord preview
+      });
+
+      grid.appendChild(button);
     });
 
-    select.addEventListener('change', (event) => {
-      const nextTheme = applyTheme(event.target.value);
-      saveTheme(nextTheme);
+    panel.appendChild(title);
+    panel.appendChild(hint);
+    panel.appendChild(grid);
+
+    function setOpen(open) {
+      panel.hidden = !open;
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+      wrapper.classList.toggle('is-open', open);
+    }
+
+    toggle.addEventListener('click', (event) => {
+      event.stopPropagation();
+      setOpen(panel.hidden);
     });
 
-    wrapper.appendChild(label);
-    wrapper.appendChild(select);
+    document.addEventListener('click', (event) => {
+      if (!wrapper.contains(event.target)) setOpen(false);
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') setOpen(false);
+    });
+
+    wrapper.appendChild(toggle);
+    wrapper.appendChild(panel);
     host.insertAdjacentElement('afterend', wrapper);
-    select.value = document.documentElement.getAttribute('data-theme') || defaultTheme;
+
+    const active = resolveTheme(document.documentElement.getAttribute('data-theme') || getSavedTheme());
+    applyTheme(active);
+    const current = THEMES.find((item) => item.value === active);
+    if (current) toggleSwatch.style.background = current.swatch;
   }
 
+  // Early apply for pages without head bootstrap.
   applyTheme(getSavedTheme());
 
   if (document.readyState === 'loading') {

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -11,6 +11,34 @@
   <meta property="og:description" content="ReverseLab 常见问题解答：项目介绍、MCP 工具使用、知识库结构、贡献指南。">
   <meta property="og:url" content="https://ling71671.github.io/open-reverselab/faq.html">
   <link rel="canonical" href="https://ling71671.github.io/open-reverselab/faq.html">
+  <script>
+    (function () {
+      try {
+        var key = 'reverselab-theme';
+        var theme = localStorage.getItem(key) || '';
+        var aliases = {
+          light: 'mint-apple', ash: 'dark', midnight: 'midnight-blurple', chroma: 'chroma-glow',
+          grape: 'retro', mocha: 'sepia', onyx: 'under-the-sea', aurora: 'forest'
+        };
+        if (aliases[theme]) theme = aliases[theme];
+        var valid = {
+          cinder:1,'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1,sunset:1,'chroma-glow':1,forest:1,crimson:1,
+          'midnight-blurple':1,mars:1,dusk:1,'under-the-sea':1,retro:1,'neon-nights':1,sepia:1,
+          blurple:1,dark:1
+        };
+        if (!valid[theme]) {
+          theme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'mint-apple';
+        }
+        var light = {
+          'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1
+        };
+        document.documentElement.setAttribute('data-theme', theme);
+        document.documentElement.style.colorScheme = light[theme] ? 'light' : 'dark';
+      } catch (e) {}
+    })();
+  </script>
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
 

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -49,7 +49,7 @@
     "mainEntity": [
       {
         "@type": "Question", "name": "什么是 ReverseLab？",
-        "acceptedAnswer": {"@type": "Answer", "text": "ReverseLab 是一个开源逆向工程实验环境，包含 197 篇深度技术文章组成的知识库、100+ MCP (Model Context Protocol) 自动化工具、以及 CTF/APK/PE 全链路自动化工作流。项目采用 '目录即约定' 设计，专为 AI Agent 辅助分析而构建。"}
+        "acceptedAnswer": {"@type": "Answer", "text": "ReverseLab 是一个开源逆向工程实验环境，包含 145 篇深度技术文章组成的知识库、100+ MCP (Model Context Protocol) 自动化工具、以及 CTF/APK/PE 全链路自动化工作流。项目采用 '目录即约定' 设计，专为 AI Agent 辅助分析而构建。"}
       },
       {
         "@type": "Question", "name": "ReverseLab 的知识库覆盖哪些领域？",
@@ -69,7 +69,7 @@
       },
       {
         "@type": "Question", "name": "ReverseLab 能用于恶意目的吗？",
-        "acceptedAnswer": {"@type": "Answer", "text": "不能。ReverseLab 遵循 GPL-3.0 许可证，仅供授权范围内的安全教育、CTF 竞赛、安全研究和防御分析使用。项目明确要求贡献者遵守技术伦理，仅参与合法授权的分析活动。"}
+        "acceptedAnswer": {"@type": "Answer", "text": "不能。ReverseLab 遵循 GPL-3.0 许可证，仅供授权范围内的安全教育、CTF 竞赛、安全研究和防御分析使用。项目明确要求贡献者遵守技术伦理，仅参与合法授权的分析活动。详见 CODE_OF_CONDUCT.md。"}
       },
       {
         "@type": "Question", "name": "项目和外部工具的关系是什么？",
@@ -77,7 +77,7 @@
       },
       {
         "@type": "Question", "name": "如何贡献？",
-        "acceptedAnswer": {"@type": "Answer", "text": "参考 CONTRIBUTING.md：只提交可公开的通用实现、模板、安装说明和合成测试数据。不提交私人实验数据。提交前必须运行 public_release_check.py、lab_healthcheck.py 和 kb_doc_audit.py。"}
+        "acceptedAnswer": {"@type": "Answer", "text": "参考 CONTRIBUTING.md：只提交可公开的通用实现、模板、安装说明和合成测试数据。不提交私人实验数据（cases/samples/exports/reports 中的实际任务产物）。提交前必须运行 public_release_check.py、lab_healthcheck.py 和 kb_doc_audit.py。建议为仓库配置 GitHub noreply 邮箱避免泄露个人信息。"}
       }
     ]
   }
@@ -108,7 +108,7 @@
     </section>
 
     <section class="faq-list">
-      <div class="faq-item"><h3>1. 什么是 ReverseLab？</h3><p>ReverseLab 是一个开源逆向工程实验环境，包含 <strong>197 篇深度技术文章</strong>组成的知识库、<strong>100+ MCP (Model Context Protocol) 自动化工具</strong>、以及 CTF/APK/PE 全链路自动化工作流。项目采用"目录即约定"设计，专为 AI Agent 辅助分析而构建。</p></div>
+      <div class="faq-item"><h3>1. 什么是 ReverseLab？</h3><p>ReverseLab 是一个开源逆向工程实验环境，包含 <strong>145 篇深度技术文章</strong>组成的知识库、<strong>100+ MCP (Model Context Protocol) 自动化工具</strong>、以及 CTF/APK/PE 全链路自动化工作流。项目采用"目录即约定"设计，专为 AI Agent 辅助分析而构建。</p></div>
 
       <div class="faq-item"><h3>2. ReverseLab 的知识库覆盖哪些领域？</h3><p>🌐 <strong>CTF Website</strong>（23 分类 97 篇）：JWT/SQLi/SSRF/XSS/CVE/DoS/Payment/Paywall/签名攻击/API/OAuth<br>📱 <strong>APK Reverse</strong>（8 分类 17 篇）：DEX/Native/IL2CPP/Frida 动态插桩/脱壳/重打包<br>🖥️ <strong>PE Reverse</strong>（8 分类 18 篇）：Ghidra 静态分析/x64dbg 动态调试/YARA/Sigma/Patch/免杀<br>🔬 <strong>General</strong>（12 篇）：Linux 内核利用/加密算法识别/PRNG 破解/游戏作弊与反作弊/协议逆向/固件/硬件</p></div>
 

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -21,11 +21,11 @@
     "mainEntity": [
       {
         "@type": "Question", "name": "什么是 ReverseLab？",
-        "acceptedAnswer": {"@type": "Answer", "text": "ReverseLab 是一个开源逆向工程实验环境，包含 178 篇深度技术文章组成的知识库、100+ MCP (Model Context Protocol) 自动化工具、以及 CTF/APK/PE 全链路自动化工作流。项目采用 '目录即约定' 设计，专为 AI Agent 辅助分析而构建。"}
+        "acceptedAnswer": {"@type": "Answer", "text": "ReverseLab 是一个开源逆向工程实验环境，包含 197 篇深度技术文章组成的知识库、100+ MCP (Model Context Protocol) 自动化工具、以及 CTF/APK/PE 全链路自动化工作流。项目采用 '目录即约定' 设计，专为 AI Agent 辅助分析而构建。"}
       },
       {
         "@type": "Question", "name": "ReverseLab 的知识库覆盖哪些领域？",
-        "acceptedAnswer": {"@type": "Answer", "text": "CTF Website（26分类118篇）：JWT/SQLi/SSRF/XSS/CVE/DoS/Payment/Paywall/云原生；APK Reverse（8分类20篇）：DEX/Native/JNI/Frida/Pinning/脱壳/重打包；PE Reverse（9分类22篇）：Ghidra/x64dbg/TLS Callback/API Resolver/IOC/YARA/Patch/免杀；General（5分类17篇）：Linux内核利用/加密算法/PRNG/游戏作弊/协议逆向/固件/硬件。"}
+        "acceptedAnswer": {"@type": "Answer", "text": "CTF Website（23分类97篇）：JWT/SQLi/SSRF/XSS/CVE/DoS/Payment/Paywall；APK Reverse（8分类17篇）：DEX/Native/IL2CPP/Frida/脱壳/重打包；PE Reverse（8分类18篇）：Ghidra/x64dbg/Triage/YARA/Patch/免杀；General（12篇）：Linux内核利用/加密算法/PRNG/游戏作弊/协议逆向/固件/硬件。"}
       },
       {
         "@type": "Question", "name": "什么是 MCP (Model Context Protocol) 工具？",
@@ -40,8 +40,8 @@
         "acceptedAnswer": {"@type": "Answer", "text": "git clone 仓库后运行 bootstrap.ps1 初始化核心脚本，然后用 install_tools.ps1 -CTF/-Android/-Windows/-Common 安装对应板块的工具链。完整验证：python scripts/misc/lab_healthcheck.py && python scripts/misc/ai_toolcheck.py。"}
       },
       {
-        "@type": "Question", "name": "ReverseLab 内置执行拦截吗？",
-        "acceptedAnswer": {"@type": "Answer", "text": "不内置。ReverseLab 提供技术文档、目录约定和自动化工具链；具体请求是否执行由使用者所接入的 AI 大模型提供商、运行平台或组织策略处理。"}
+        "@type": "Question", "name": "ReverseLab 能用于恶意目的吗？",
+        "acceptedAnswer": {"@type": "Answer", "text": "不能。ReverseLab 遵循 GPL-3.0 许可证，仅供授权范围内的安全教育、CTF 竞赛、安全研究和防御分析使用。项目明确要求贡献者遵守技术伦理，仅参与合法授权的分析活动。"}
       },
       {
         "@type": "Question", "name": "项目和外部工具的关系是什么？",
@@ -49,11 +49,12 @@
       },
       {
         "@type": "Question", "name": "如何贡献？",
-        "acceptedAnswer": {"@type": "Answer", "text": "参考 CONTRIBUTING.md。新增或修改内容后运行 public_release_check.py、lab_healthcheck.py 和 kb_doc_audit.py，确保目录、索引和文档结构保持一致。"}
+        "acceptedAnswer": {"@type": "Answer", "text": "参考 CONTRIBUTING.md：只提交可公开的通用实现、模板、安装说明和合成测试数据。不提交私人实验数据。提交前必须运行 public_release_check.py、lab_healthcheck.py 和 kb_doc_audit.py。"}
       }
     ]
   }
   </script>
+  <script src="assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -79,11 +80,11 @@
     </section>
 
     <section class="faq-list">
-      <div class="faq-item"><h3>1. 什么是 ReverseLab？</h3><p>ReverseLab 是一个开源逆向工程实验环境，包含 <strong>178 篇深度技术文章</strong>组成的知识库、<strong>100+ MCP (Model Context Protocol) 自动化工具</strong>、以及 CTF/APK/PE 全链路自动化工作流。项目采用"目录即约定"设计，专为 AI Agent 辅助分析而构建。</p></div>
+      <div class="faq-item"><h3>1. 什么是 ReverseLab？</h3><p>ReverseLab 是一个开源逆向工程实验环境，包含 <strong>197 篇深度技术文章</strong>组成的知识库、<strong>100+ MCP (Model Context Protocol) 自动化工具</strong>、以及 CTF/APK/PE 全链路自动化工作流。项目采用"目录即约定"设计，专为 AI Agent 辅助分析而构建。</p></div>
 
-      <div class="faq-item"><h3>2. ReverseLab 的知识库覆盖哪些领域？</h3><p>🌐 <strong>CTF Website</strong>（26 分类 118 篇）：JWT/SQLi/SSRF/XSS/CVE/DoS/Payment/Paywall/签名攻击/API/OAuth/云原生/IAM<br>📱 <strong>APK Reverse</strong>（8 分类 20 篇）：DEX/Native/JNI/IL2CPP/Frida/Pinning/脱壳/重打包<br>🖥️ <strong>PE Reverse</strong>（9 分类 22 篇）：Ghidra 静态分析/x64dbg 动态调试/TLS Callback/API Resolver/IOC/YARA/Sigma/Patch/免杀<br>🔬 <strong>General</strong>（5 分类 17 篇）：Linux 内核利用/加密算法识别/PRNG 破解/游戏作弊与反作弊/协议逆向/固件/硬件</p></div>
+      <div class="faq-item"><h3>2. ReverseLab 的知识库覆盖哪些领域？</h3><p>🌐 <strong>CTF Website</strong>（23 分类 97 篇）：JWT/SQLi/SSRF/XSS/CVE/DoS/Payment/Paywall/签名攻击/API/OAuth<br>📱 <strong>APK Reverse</strong>（8 分类 17 篇）：DEX/Native/IL2CPP/Frida 动态插桩/脱壳/重打包<br>🖥️ <strong>PE Reverse</strong>（8 分类 18 篇）：Ghidra 静态分析/x64dbg 动态调试/YARA/Sigma/Patch/免杀<br>🔬 <strong>General</strong>（12 篇）：Linux 内核利用/加密算法识别/PRNG 破解/游戏作弊与反作弊/协议逆向/固件/硬件</p></div>
 
-      <div class="faq-item"><h3>3. 什么是 MCP (Model Context Protocol) 工具？为什么它很重要？</h3><p>MCP 是 AI 模型与外部工具交互的<strong>标准协议</strong>（由 Anthropic 提出）。ReverseLab 的 MCP 工具让 AI Agent 可以<strong>直接调用</strong>逆向分析工具，无需人工手动执行。例如：AI 检测到 JWT Token → 自动调用 <code>kb_router</code> 查技术 → <code>kb_read_file</code> 读攻击方法 → <code>http_probe</code> 发探测请求 → 判断是否存在漏洞。这在整个开源工具生态中<strong>非常罕见</strong>，是 ReverseLab 的核心差异化优势。</p></div>
+      <div class="faq-item"><h3>3. 什么是 MCP (Model Context Protocol) 工具？为什么它很重要？</h3><p>MCP 是 AI 模型与外部工具交互的<strong>标准协议</strong>（由 Anthropic 提出）。ReverseLab 的 MCP 工具让 AI Agent 可以<strong>直接调用</strong>逆向分析工具，无需人工手动执行。例如：AI 检测到 JWT Token → 自动调用 <code>kb_router</code> 查技术 → <code>kb_read_file</code> 读攻击方法 → <code>http_probe</code> 发探测请求 → 判断是否存在漏洞。这在整个开源安全工具生态中<strong>非常罕见</strong>，是 ReverseLab 的核心差异化优势。</p></div>
 
       <div class="faq-item"><h3>4. AI Agent 如何使用 ReverseLab 进行自动化分析？</h3><p>AI Agent 加载项目后沿上下文链（CLAUDE.md → AGENTS.md → AI-USAGE.md → boards/&lt;board&gt;/AI-USAGE.md）理解约定。检测到信号后：① 调用 <code>kb_router</code> 查找相关技术文章 → ② 调用 <code>kb_read_file</code> 读取文章内容和可运行代码 → ③ 按照文章中的 <strong>MCP 工具映射表</strong>自动调用对应工具 → ④ 收集证据、记录笔记、生成报告。</p></div>
 
@@ -99,11 +100,11 @@ cd open-reverselab
 python scripts/misc/lab_healthcheck.py
 python scripts/misc/ai_toolcheck.py</pre></div>
 
-      <div class="faq-item"><h3>6. ReverseLab 内置执行拦截吗？</h3><p>不内置。ReverseLab 提供技术文档、目录约定和自动化工具链；具体请求是否执行由使用者所接入的 AI 大模型提供商、运行平台或组织策略处理。</p></div>
+      <div class="faq-item"><h3>6. ReverseLab 能用于恶意目的吗？</h3><p><strong>不能。</strong>ReverseLab 遵循 GPL-3.0 许可证，仅供授权范围内的安全教育、CTF 竞赛、安全研究和防御分析使用。项目明确要求贡献者遵守技术伦理，仅参与合法授权的分析活动。详见 <a href="https://github.com/LING71671/open-reverselab/blob/main/CODE_OF_CONDUCT.md">CODE_OF_CONDUCT</a>。</p></div>
 
       <div class="faq-item"><h3>7. ReverseLab 与 Ghidra/x64dbg/Frida 等工具的关系是什么？</h3><p>ReverseLab 是一个<strong>知识库和自动化编排层</strong>，它集成但不捆绑这些外部工具。支持的工具有：Ghidra（NSA 反编译器）、x64dbg（Windows 调试器）、Frida（动态插桩）、JADX（APK 反编译）、sqlmap、Burp Suite、nmap、DirSearch、Cheat Engine、PE-bear、DiE、Procmon、HxD、Cutter/Rizin 以及各种 Python CTF 库。</p></div>
 
-      <div class="faq-item"><h3>8. 如何为 ReverseLab 贡献？</h3><p>参考 <a href="https://github.com/LING71671/open-reverselab/blob/main/CONTRIBUTING.md">CONTRIBUTING.md</a>。新增或修改内容后运行 <code>public_release_check.py</code>、<code>lab_healthcheck.py</code> 和 <code>kb_doc_audit.py</code>，确保目录、索引和文档结构保持一致。</p></div>
+      <div class="faq-item"><h3>8. 如何为 ReverseLab 贡献？</h3><p>参考 <a href="https://github.com/LING71671/open-reverselab/blob/main/CONTRIBUTING.md">CONTRIBUTING.md</a>：<br>① 只提交可公开的通用实现、模板、安装说明和合成测试数据<br>② 不提交私人实验数据（cases/samples/exports/reports 中的实际任务产物）<br>③ 提交前必须运行：<code>public_release_check.py</code>、<code>lab_healthcheck.py</code>、<code>kb_doc_audit.py</code><br>④ 建议为仓库配置 GitHub noreply 邮箱避免泄露个人信息</p></div>
     </section>
   </main>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,14 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ReverseLab — 开源逆向工程实验环境 | MCP 工具生态</title>
-  <meta name="description" content="ReverseLab 是开源逆向工程实验环境，包含 178 篇知识库文章、100+ MCP 自动化工具，覆盖 CTF 渗透测试、APK 逆向、PE 二进制分析、加密协议破解、游戏作弊分析。Agent 原生设计。">
+  <meta name="description" content="ReverseLab 是开源逆向工程实验环境，包含 197 篇知识库文章、100+ MCP 自动化工具，覆盖 CTF 渗透测试、APK 逆向、PE 二进制分析、加密协议破解、游戏作弊分析。Agent 原生设计。">
   <meta name="keywords" content="reverse engineering, 逆向工程, CTF, APK reverse, PE analysis, MCP tools, Frida, Ghidra, x64dbg, web security, binary analysis, knowledge base, 知识库, malware analysis, vulnerability research">
   <meta name="author" content="ReverseLab">
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
 
   <!-- Open Graph -->
   <meta property="og:title" content="ReverseLab — 开源逆向工程实验环境 | MCP 工具生态">
-  <meta property="og:description" content="178 篇知识库文章，100+ MCP 自动化工具，覆盖 CTF/APK/PE/加密/游戏作弊全领域逆向工程。Agent 原生，目录即约定。">
+  <meta property="og:description" content="197 篇知识库文章，100+ MCP 自动化工具，覆盖 CTF/APK/PE/加密/游戏作弊全领域逆向工程。Agent 原生，目录即约定。">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://ling71671.github.io/open-reverselab/">
   <meta property="og:image" content="https://ling71671.github.io/open-reverselab/assets/social-preview.png">
@@ -21,7 +21,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="ReverseLab — 开源逆向工程实验环境">
-  <meta name="twitter:description" content="178 篇知识库文章 + 100+ MCP 自动化工具。CTF/APK/PE/加密全领域覆盖。">
+  <meta name="twitter:description" content="197 篇知识库文章 + 100+ MCP 自动化工具。CTF/APK/PE/加密全领域覆盖。">
   <meta name="twitter:image" content="https://ling71671.github.io/open-reverselab/assets/social-preview.png">
 
   <!-- Canonical -->
@@ -37,7 +37,7 @@
     "@type": "SoftwareSourceCode",
     "@id": "https://github.com/LING71671/open-reverselab",
     "name": "ReverseLab",
-    "description": "Open-source reverse engineering lab: 178-article knowledge base + MCP tools + CTF/APK/PE automation toolchain. Agent-native.",
+    "description": "Open-source reverse engineering lab: 197-article knowledge base + MCP tools + CTF/APK/PE automation toolchain. Agent-native.",
     "url": "https://github.com/LING71671/open-reverselab",
     "codeRepository": "https://github.com/LING71671/open-reverselab",
     "programmingLanguage": ["Python", "JavaScript", "PowerShell", "C++"],
@@ -60,6 +60,7 @@
 
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
+  <script src="assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -79,7 +80,7 @@
   <main class="container">
     <!-- Hero -->
     <section class="hero">
-      <h2>178 篇技术文章 · 100+ MCP 工具 · 5 大分析板块</h2>
+      <h2>197 篇技术文章 · 100+ MCP 工具 · 5 大分析板块</h2>
       <p class="hero-desc">
         覆盖 CTF 渗透测试、Android APK 逆向、Windows PE 二进制分析、加密协议破解、游戏作弊分析的
         完整逆向工程知识体系。每篇文章包含可运行代码、攻击链图谱、MCP 工具映射。
@@ -98,25 +99,25 @@
           <span class="board-icon">🌐</span>
           <h3>CTF Website</h3>
           <p>Web 攻击全表面 — JWT / SQLi / SSRF / XSS / CORS / OAuth / CVE / DoS / Payment</p>
-          <span class="board-stat">26 分类 · 118 篇</span>
+          <span class="board-stat">23 分类 · 97 篇</span>
         </a>
         <a href="kb/apk-reverse/index.html" class="board-card">
           <span class="board-icon">📱</span>
           <h3>APK Reverse</h3>
           <p>Android 逆向 — DEX / Native / IL2CPP / Frida Hook / 加密破解 / 脱壳</p>
-          <span class="board-stat">8 分类 · 20 篇</span>
+          <span class="board-stat">8 分类 · 17 篇</span>
         </a>
         <a href="kb/pe-reverse/index.html" class="board-card">
           <span class="board-icon">🖥️</span>
           <h3>PE Reverse</h3>
           <p>Windows 二进制分析 — Ghidra / x64dbg / Triage / IOC / YARA / Patch / 免杀</p>
-          <span class="board-stat">9 分类 · 22 篇</span>
+          <span class="board-stat">8 分类 · 18 篇</span>
         </a>
         <a href="kb/general/index.html" class="board-card">
           <span class="board-icon">🔬</span>
           <h3>General</h3>
           <p>跨领域 — 密码学 / 协议逆向 / 内核利用 / 游戏作弊 / 固件 / SDR / AI 安全</p>
-          <span class="board-stat">5 分类 · 17 篇</span>
+          <span class="board-stat">8 分类 · 12 篇</span>
         </a>
         <a href="kb/windows/index.html" class="board-card">
           <span class="board-icon">🪟</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -58,6 +58,34 @@
   }
   </script>
 
+  <script>
+    (function () {
+      try {
+        var key = 'reverselab-theme';
+        var theme = localStorage.getItem(key) || '';
+        var aliases = {
+          light: 'mint-apple', ash: 'dark', midnight: 'midnight-blurple', chroma: 'chroma-glow',
+          grape: 'retro', mocha: 'sepia', onyx: 'under-the-sea', aurora: 'forest'
+        };
+        if (aliases[theme]) theme = aliases[theme];
+        var valid = {
+          cinder:1,'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1,sunset:1,'chroma-glow':1,forest:1,crimson:1,
+          'midnight-blurple':1,mars:1,dusk:1,'under-the-sea':1,retro:1,'neon-nights':1,sepia:1,
+          blurple:1,dark:1
+        };
+        if (!valid[theme]) {
+          theme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'mint-apple';
+        }
+        var light = {
+          'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1
+        };
+        document.documentElement.setAttribute('data-theme', theme);
+        document.documentElement.style.colorScheme = light[theme] ? 'light' : 'dark';
+      } catch (e) {}
+    })();
+  </script>
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
   <script src="assets/js/theme.js" defer></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,14 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ReverseLab — 开源逆向工程实验环境 | MCP 工具生态</title>
-  <meta name="description" content="ReverseLab 是开源逆向工程实验环境，包含 197 篇知识库文章、100+ MCP 自动化工具，覆盖 CTF 渗透测试、APK 逆向、PE 二进制分析、加密协议破解、游戏作弊分析。Agent 原生设计。">
+  <meta name="description" content="ReverseLab 是开源逆向工程实验环境，包含 145 篇知识库文章、100+ MCP 自动化工具，覆盖 CTF 渗透测试、APK 逆向、PE 二进制分析、加密协议破解、游戏作弊分析。Agent 原生设计。">
   <meta name="keywords" content="reverse engineering, 逆向工程, CTF, APK reverse, PE analysis, MCP tools, Frida, Ghidra, x64dbg, web security, binary analysis, knowledge base, 知识库, malware analysis, vulnerability research">
   <meta name="author" content="ReverseLab">
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
 
   <!-- Open Graph -->
   <meta property="og:title" content="ReverseLab — 开源逆向工程实验环境 | MCP 工具生态">
-  <meta property="og:description" content="197 篇知识库文章，100+ MCP 自动化工具，覆盖 CTF/APK/PE/加密/游戏作弊全领域逆向工程。Agent 原生，目录即约定。">
+  <meta property="og:description" content="145 篇知识库文章，100+ MCP 自动化工具，覆盖 CTF/APK/PE/加密/游戏作弊全领域逆向工程。Agent 原生，目录即约定。">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://ling71671.github.io/open-reverselab/">
   <meta property="og:image" content="https://ling71671.github.io/open-reverselab/assets/social-preview.png">
@@ -21,7 +21,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="ReverseLab — 开源逆向工程实验环境">
-  <meta name="twitter:description" content="197 篇知识库文章 + 100+ MCP 自动化工具。CTF/APK/PE/加密全领域覆盖。">
+  <meta name="twitter:description" content="145 篇知识库文章 + 100+ MCP 自动化工具。CTF/APK/PE/加密全领域覆盖。">
   <meta name="twitter:image" content="https://ling71671.github.io/open-reverselab/assets/social-preview.png">
 
   <!-- Canonical -->
@@ -37,7 +37,7 @@
     "@type": "SoftwareSourceCode",
     "@id": "https://github.com/LING71671/open-reverselab",
     "name": "ReverseLab",
-    "description": "Open-source reverse engineering lab: 197-article knowledge base + MCP tools + CTF/APK/PE automation toolchain. Agent-native.",
+    "description": "Open-source reverse engineering lab: 145-article knowledge base + MCP tools + CTF/APK/PE automation toolchain. Agent-native.",
     "url": "https://github.com/LING71671/open-reverselab",
     "codeRepository": "https://github.com/LING71671/open-reverselab",
     "programmingLanguage": ["Python", "JavaScript", "PowerShell", "C++"],
@@ -108,7 +108,7 @@
   <main class="container">
     <!-- Hero -->
     <section class="hero">
-      <h2>197 篇技术文章 · 100+ MCP 工具 · 5 大分析板块</h2>
+      <h2>145 篇技术文章 · 100+ MCP 工具 · 5 大分析板块</h2>
       <p class="hero-desc">
         覆盖 CTF 渗透测试、Android APK 逆向、Windows PE 二进制分析、加密协议破解、游戏作弊分析的
         完整逆向工程知识体系。每篇文章包含可运行代码、攻击链图谱、MCP 工具映射。

--- a/docs/kb/apk-reverse/index.html
+++ b/docs/kb/apk-reverse/index.html
@@ -11,6 +11,34 @@
   <meta property="og:description" content="8 分类 17 篇 Android 逆向技术文章。DEX/Native/IL2CPP/UE4/Frida/加密/脱壳全覆盖。">
   <meta property="og:url" content="https://ling71671.github.io/open-reverselab/kb/apk-reverse/">
   <link rel="canonical" href="https://ling71671.github.io/open-reverselab/kb/apk-reverse/">
+  <script>
+    (function () {
+      try {
+        var key = 'reverselab-theme';
+        var theme = localStorage.getItem(key) || '';
+        var aliases = {
+          light: 'mint-apple', ash: 'dark', midnight: 'midnight-blurple', chroma: 'chroma-glow',
+          grape: 'retro', mocha: 'sepia', onyx: 'under-the-sea', aurora: 'forest'
+        };
+        if (aliases[theme]) theme = aliases[theme];
+        var valid = {
+          cinder:1,'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1,sunset:1,'chroma-glow':1,forest:1,crimson:1,
+          'midnight-blurple':1,mars:1,dusk:1,'under-the-sea':1,retro:1,'neon-nights':1,sepia:1,
+          blurple:1,dark:1
+        };
+        if (!valid[theme]) {
+          theme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'mint-apple';
+        }
+        var light = {
+          'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1
+        };
+        document.documentElement.setAttribute('data-theme', theme);
+        document.documentElement.style.colorScheme = light[theme] ? 'light' : 'dark';
+      } catch (e) {}
+    })();
+  </script>
   <link rel="stylesheet" href="../../assets/css/style.css">
   <link rel="icon" type="image/svg+xml" href="../../assets/img/favicon.svg">
 

--- a/docs/kb/apk-reverse/index.html
+++ b/docs/kb/apk-reverse/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>APK Reverse 知识库 | ReverseLab — Android 逆向 20 篇</title>
-  <meta name="description" content="APK 逆向技术知识库：8 分类 20 篇文章，覆盖 DEX/Java 修改、Native/SO/JNI 逆向、加密破解、网络协议 Hook、TLS Pinning、Frida 动态插桩、脱壳、重打包。每篇含可运行 Frida/C++ 代码。">
+  <title>APK Reverse 知识库 | ReverseLab — Android 逆向 17 篇</title>
+  <meta name="description" content="APK 逆向技术知识库：8 分类 17 篇文章，覆盖 DEX/Java 修改、Native/SO 逆向（IL2CPP/UE4）、加密破解、网络协议 Hook、Frida 动态插桩、脱壳、重打包。每篇含可运行 Frida/C++ 代码。">
   <meta name="keywords" content="APK reverse engineering, Android reverse, Frida, IL2CPP, UE4, smali, DEX, SO injection, game hacking, APK 逆向, 安卓逆向, 游戏破解">
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="APK Reverse 知识库 | ReverseLab">
-  <meta property="og:description" content="8 分类 20 篇 Android 逆向技术文章。DEX/Native/JNI/IL2CPP/UE4/Frida/Pinning/脱壳全覆盖。">
+  <meta property="og:description" content="8 分类 17 篇 Android 逆向技术文章。DEX/Native/IL2CPP/UE4/Frida/加密/脱壳全覆盖。">
   <meta property="og:url" content="https://ling71671.github.io/open-reverselab/kb/apk-reverse/">
   <link rel="canonical" href="https://ling71671.github.io/open-reverselab/kb/apk-reverse/">
   <link rel="stylesheet" href="../../assets/css/style.css">
@@ -19,12 +19,13 @@
     "@context": "https://schema.org",
     "@type": "TechArticleSeries",
     "name": "ReverseLab APK Reverse Engineering Knowledge Base",
-    "description": "8 categories, 20 articles: DEX/Java, Native/SO/JNI, crypto cracking, network protocol hooking, TLS pinning, Frida dynamic instrumentation, unpacking, repackaging.",
-    "numberOfItems": 20,
+    "description": "8 categories, 17 articles: DEX/Java, Native/SO (IL2CPP/UE4), crypto cracking, network protocol hooking, Frida dynamic instrumentation, unpacking, repackaging.",
+    "numberOfItems": 17,
     "inLanguage": "zh-CN",
     "isPartOf": {"@type": "SoftwareSourceCode", "name": "ReverseLab", "url": "https://github.com/LING71671/open-reverselab"}
   }
   </script>
+  <script src="../../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -46,7 +47,7 @@
 
     <section class="hero">
       <h2>📱 APK Reverse — Android 逆向工程</h2>
-      <p class="hero-desc">8 分类 · 20 篇技术文章。覆盖静态分析、Frida 动态验证、TLS Pinning、脱壳、Patch 与重打包。</p>
+      <p class="hero-desc">8 分类 · 17 篇技术文章。覆盖静态分析、Frida 动态验证、脱壳、Patch 与重打包。</p>
       <div class="hero-actions">
         <a href="https://github.com/LING71671/open-reverselab/tree/main/kb/apk-reverse/techniques" class="btn-primary">GitHub 上浏览全部文章</a>
         <a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/attack-network.md" class="btn-secondary">查看攻击网图谱</a>
@@ -58,19 +59,19 @@
 
       <div class="kb-category"><h3>01-dex-java — DEX/Java（1 篇）</h3><p>Smali 代码注入与 DEX 修改</p><ul><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/01-dex-java/01-smali-injection.md">Smali 代码注入与 DEX 修改</a></li></ul></div>
 
-      <div class="kb-category"><h3>02-native — Native/SO（6 篇）</h3><p>Unity IL2CPP、指针链遍历、UE4 引擎游戏偏移发现、Kernel Driver proc 节点注入、虚拟地址→物理地址转换、JNI RegisterNatives</p><ul><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/02-native/01-il2cpp-offset-discovery.md">Unity IL2CPP 静态逆向与偏移发现</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/02-native/02-pointer-chain-patterns.md">指针链遍历模式</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/02-native/03-ue4-offset-hunting.md">UE4 引擎游戏偏移发现</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/02-native/04-kernel-procfs-driver.md">Kernel Driver 注入：proc 节点读写</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/02-native/05-virt-phys-memory.md">虚拟地址 → 物理地址转换</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/02-native/06-jni-register-natives-tracing.md">JNI RegisterNatives 追踪与 Native 入口还原</a></li></ul></div>
+      <div class="kb-category"><h3>02-native — Native/SO（5 篇）</h3><p>Unity IL2CPP、指针链遍历、UE4 引擎游戏偏移发现、Kernel Driver proc 节点注入、虚拟地址→物理地址转换</p><ul><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/02-native/01-il2cpp-offset-discovery.md">Unity IL2CPP 静态逆向与偏移发现</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/02-native/02-pointer-chain-patterns.md">指针链遍历模式</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/02-native/03-ue4-offset-hunting.md">UE4 引擎游戏偏移发现</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/02-native/04-kernel-procfs-driver.md">Kernel Driver 注入：proc 节点读写</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/02-native/05-virt-phys-memory.md">虚拟地址 → 物理地址转换</a></li></ul></div>
 
       <div class="kb-category"><h3>03-manifest — Manifest/入口（1 篇）</h3><ul><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/03-manifest/01-entry-point-tracing.md">入口点追踪与组件分析</a></li></ul></div>
 
       <div class="kb-category"><h3>04-crypto — 加密（2 篇）</h3><ul><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/04-crypto/01-game-encryption-patterns.md">游戏数据加解密识别与绕过</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/04-crypto/02-rc4-custom-crypto.md">自定义对称加密：RC4 与组合模式</a></li></ul></div>
 
-      <div class="kb-category"><h3>05-network — 网络协议（3 篇）</h3><ul><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/05-network/01-game-protocol-hook.md">游戏协议 Hook 与封包分析</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/05-network/02-license-verification-bypass.md">在线验证系统分析与绕过</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/05-network/03-tls-pinning-unpinning.md">TLS Pinning 定位与 Unpinning</a></li></ul></div>
+      <div class="kb-category"><h3>05-network — 网络协议（2 篇）</h3><ul><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/05-network/01-game-protocol-hook.md">游戏协议 Hook 与封包分析</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/05-network/02-license-verification-bypass.md">在线验证系统分析与绕过</a></li></ul></div>
 
       <div class="kb-category"><h3>06-dynamic — 动态插桩（3 篇）</h3><ul><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/06-dynamic/01-memory-rw-hook.md">进程内存读写检测与 Hook</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/06-dynamic/02-overlay-rendering-hook.md">Overlay 渲染与 ImGui 检测</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/06-dynamic/03-touch-input-hook.md">触摸输入 Hook 与注入分析</a></li></ul></div>
 
       <div class="kb-category"><h3>07-packer — 壳与混淆（2 篇）</h3><ul><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/07-packer/01-obfuscation-detection.md">编译期混淆检测与识别</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/07-packer/02-self-extracting-payload.md">自解压 Payload 与脚本嵌入</a></li></ul></div>
 
-      <div class="kb-category"><h3>08-patch-repack — Patch/重打包（2 篇）</h3><ul><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/08-patch-repack/01-so-injection-repack.md">Native SO 注入与 APK 重打包</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/08-patch-repack/02-signature-integrity-bypass.md">签名与完整性检查绕过</a></li></ul></div>
+      <div class="kb-category"><h3>08-patch-repack — Patch/重打包（1 篇）</h3><ul><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/apk-reverse/techniques/08-patch-repack/01-so-injection-repack.md">Native SO 注入与 APK 重打包</a></li></ul></div>
     </section>
   </main>
 

--- a/docs/kb/ctf-website/index.html
+++ b/docs/kb/ctf-website/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>CTF Website 知识库 | ReverseLab — Web 攻击全表面 118 篇</title>
-  <meta name="description" content="CTF Website 渗透测试知识库：26 分类 118 篇技术文章，覆盖 JWT/SQLi/SSRF/XSS/CORS/OAuth/CVE/DoS/Payment/Paywall/签名攻击/API 攻击/供应链安全/云原生/IAM。每篇含可运行代码和 MCP 工具映射。">
+  <title>CTF Website 知识库 | ReverseLab — Web 攻击全表面 97 篇</title>
+  <meta name="description" content="CTF Website 渗透测试知识库：23 分类 97 篇技术文章，覆盖 JWT/SQLi/SSRF/XSS/CORS/OAuth/CVE/DoS/Payment/Paywall/签名攻击/API 攻击/供应链安全。每篇含可运行代码和 MCP 工具映射。">
   <meta name="keywords" content="CTF, web security, JWT, SQL injection, SSRF, XSS, CSRF, CORS, OAuth, CVE, DoS, payment bypass, paywall, API security, web penetration testing, 渗透测试, Web安全">
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="CTF Website 知识库 | ReverseLab">
-  <meta property="og:description" content="26 分类 118 篇 Web 安全技术文章。JWT/SQLi/SSRF/XSS/CVE/DoS/Payment/Paywall/云原生全覆盖。">
+  <meta property="og:description" content="23 分类 97 篇 Web 安全技术文章。JWT/SQLi/SSRF/XSS/CVE/DoS/Payment/Paywall 全覆盖。">
   <meta property="og:url" content="https://ling71671.github.io/open-reverselab/kb/ctf-website/">
   <meta property="og:type" content="website">
   <link rel="canonical" href="https://ling71671.github.io/open-reverselab/kb/ctf-website/">
@@ -20,12 +20,13 @@
     "@context": "https://schema.org",
     "@type": "TechArticleSeries",
     "name": "ReverseLab CTF Website Knowledge Base",
-    "description": "26 categories, 118 articles covering the full web attack surface: JWT, SQLi, SSRF, XSS, CORS, OAuth, CVE, DoS, Payment, Paywall, API attacks, supply chain, cloud native, IAM, and more.",
-    "numberOfItems": 118,
+    "description": "23 categories, 97 articles covering the full web attack surface: JWT, SQLi, SSRF, XSS, CORS, OAuth, CVE, DoS, Payment, Paywall, API attacks, supply chain, and more.",
+    "numberOfItems": 97,
     "inLanguage": "zh-CN",
     "isPartOf": {"@type": "SoftwareSourceCode", "name": "ReverseLab", "url": "https://github.com/LING71671/open-reverselab"}
   }
   </script>
+  <script src="../../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -47,7 +48,7 @@
 
     <section class="hero">
       <h2>🌐 CTF Website — Web 攻击全表面</h2>
-      <p class="hero-desc">26 分类 · 118 篇技术文章。覆盖从信息收集到漏洞利用、从认证绕过到 DoS 与云原生/IAM 的完整 Web 攻击面。</p>
+      <p class="hero-desc">23 分类 · 97 篇技术文章。覆盖从信息收集到漏洞利用、从认证绕过到 DoS 的完整 Web 攻击面。</p>
       <div class="hero-actions">
         <a href="https://github.com/LING71671/open-reverselab/tree/main/kb/ctf-website/techniques" class="btn-primary">GitHub 上浏览全部文章</a>
         <a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/attack-network.md" class="btn-secondary">查看攻击网图谱</a>
@@ -59,7 +60,7 @@
 
       <div class="kb-category"><h3>01-recon — 信息收集（5 篇）</h3><p>FOFA 资产测绘、Cloudflare 绕过、验证码绕过、版本指纹、路由绕过</p><ul><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/01-recon/captcha-bypass.md">验证码绕过技术与自动化</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/01-recon/cloudflare-bypass.md">Cloudflare 绕过：寻找真实源服务器 IP</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/01-recon/fofa-hunting.md">FOFA 资产测绘与漏洞狩猎</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/01-recon/recon-routing.md">Recon & 路由绕过</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/01-recon/version-fingerprinting.md">版本指纹识别</a></li></ul></div>
 
-      <div class="kb-category"><h3>02-auth — 认证与会话（14 篇）</h3><p>JWT 攻击全景（10 篇子系列）、Host Header、LDAP、OAuth 2.0/OIDC、SAML</p><ul><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/02-auth/jwt/00-overview.md">JWT 攻击全景</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/02-auth/jwt/01-alg-none.md">JWT alg:none 签名绕过</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/02-auth/jwt/02-algorithm-confusion.md">JWT 算法混淆</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/02-auth/jwt/03-weak-key-bruteforce.md">JWT 弱密钥爆破</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/02-auth/jwt/04-kid-injection.md">JWT kid 参数注入</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/02-auth/jwt/09-toolchain-operations.md">JWT 工具链与结果矩阵</a></li><li style="text-align:center; color: var(--text-muted);">... 共 14 篇（JWT 10 篇 + OAuth/LDAP/SAML/Host Header）</li></ul></div>
+      <div class="kb-category"><h3>02-auth — 认证与会话（14 篇）</h3><p>JWT 攻击全景（10 篇子系列）、Host Header、LDAP、OAuth 2.0/OIDC、SAML</p><ul><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/02-auth/jwt/00-overview.md">JWT 攻击全景</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/02-auth/jwt/01-alg-none.md">JWT alg:none 签名绕过</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/02-auth/jwt/02-algorithm-confusion.md">JWT 算法混淆</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/02-auth/jwt/03-weak-key-bruteforce.md">JWT 弱密钥爆破</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/02-auth/jwt/04-kid-injection.md">JWT kid 参数注入</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/02-auth/jwt/09-toolchain-defense.md">JWT 工具链与防御矩阵</a></li><li style="text-align:center; color: var(--text-muted);">... 共 14 篇（JWT 10 篇 + OAuth/LDAP/SAML/Host Header）</li></ul></div>
 
       <div class="kb-category"><h3>03-injection — 注入（7 篇）</h3><p>SQLi/NoSQLi、SSTI、GraphQL、gRPC/Protobuf、HPP/CRLF、Prototype Pollution、ReDoS</p><ul><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/03-injection/sqli-nosqli.md">SQLi & NoSQLi（数据库注入高阶实战）</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/03-injection/ssti.md">SSTI（服务端模板注入）</a></li><li><a href="https://github.com/LING71671/open-reverselab/blob/main/kb/ctf-website/techniques/03-injection/graphql.md">GraphQL 攻击实战</a></li><li style="text-align:center; color: var(--text-muted);">... 共 7 篇</li></ul></div>
 
@@ -67,7 +68,7 @@
 
       <div class="kb-category"><h3>07-client — 客户端安全（6 篇）</h3><p>Admin Bot/XSS、CORS/CSRF、JS Runtime/Browser Reversing、PostMessage、Web Crypto API、WebSocket</p></div>
 
-      <div class="kb-category"><h3>08-infra | 10-cloud | 11-supply-chain（12 篇）</h3><p>HTTP/2、Race Condition/Cache Poisoning/Request Smuggling、CI/CD、GitHub Actions、AWS IAM、Kubernetes RBAC、容器运行时、Terraform State、Kubernetes 容器逃逸、Serverless/Lambda、Dependency Confusion</p></div>
+      <div class="kb-category"><h3>08-infra | 10-cloud | 11-supply-chain（7 篇）</h3><p>HTTP/2、Race Condition/Cache Poisoning/Request Smuggling、CI/CD、Kubernetes 容器逃逸、Serverless/Lambda、Dependency Confusion</p></div>
 
       <div class="kb-category"><h3>09-cve — CVE 工作流（9 篇）</h3><p>CVE 关联网、CVE 工作流、多 CVE 链式利用 + 6 篇实战：Blink UAF、Redis RCE、cPanel 路径穿越、Nezha JWT 伪造、LiteLLM 提权、NGINX 堆溢出</p></div>
 

--- a/docs/kb/ctf-website/index.html
+++ b/docs/kb/ctf-website/index.html
@@ -12,6 +12,34 @@
   <meta property="og:url" content="https://ling71671.github.io/open-reverselab/kb/ctf-website/">
   <meta property="og:type" content="website">
   <link rel="canonical" href="https://ling71671.github.io/open-reverselab/kb/ctf-website/">
+  <script>
+    (function () {
+      try {
+        var key = 'reverselab-theme';
+        var theme = localStorage.getItem(key) || '';
+        var aliases = {
+          light: 'mint-apple', ash: 'dark', midnight: 'midnight-blurple', chroma: 'chroma-glow',
+          grape: 'retro', mocha: 'sepia', onyx: 'under-the-sea', aurora: 'forest'
+        };
+        if (aliases[theme]) theme = aliases[theme];
+        var valid = {
+          cinder:1,'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1,sunset:1,'chroma-glow':1,forest:1,crimson:1,
+          'midnight-blurple':1,mars:1,dusk:1,'under-the-sea':1,retro:1,'neon-nights':1,sepia:1,
+          blurple:1,dark:1
+        };
+        if (!valid[theme]) {
+          theme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'mint-apple';
+        }
+        var light = {
+          'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1
+        };
+        document.documentElement.setAttribute('data-theme', theme);
+        document.documentElement.style.colorScheme = light[theme] ? 'light' : 'dark';
+      } catch (e) {}
+    })();
+  </script>
   <link rel="stylesheet" href="../../assets/css/style.css">
   <link rel="icon" type="image/svg+xml" href="../../assets/img/favicon.svg">
 

--- a/docs/kb/general/index.html
+++ b/docs/kb/general/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>General 知识库 | ReverseLab — 跨领域逆向 17 篇</title>
-  <meta name="description" content="通用逆向技术知识库：17 篇文章覆盖 Linux 内核利用、加密算法识别（AES/DES/RSA）、PRNG 破解、游戏作弊与反作弊（EAC/BE/Vanguard）、协议逆向（Protobuf/Flatbuffers）、固件/硬件/无线电逆向。">
+  <title>General 知识库 | ReverseLab — 跨领域逆向 12 篇</title>
+  <meta name="description" content="通用逆向技术知识库：12 篇文章覆盖 Linux 内核利用、加密算法识别（AES/DES/RSA）、PRNG 破解、游戏作弊与反作弊（EAC/BE/Vanguard）、协议逆向（Protobuf/Flatbuffers）、固件/硬件/无线电逆向。">
   <meta name="keywords" content="cryptography, protocol reverse engineering, Linux kernel exploit, game cheating, anti-cheat, PRNG, Protobuf, firmware, hardware hacking, SDR, 密码学, 协议逆向, 内核, 游戏作弊, 反作弊">
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="General 知识库 | ReverseLab">
-  <meta property="og:description" content="17 篇跨领域逆向文章。内核/Crypto/PRNG/游戏作弊/协议/固件/硬件全覆盖。">
+  <meta property="og:description" content="12 篇跨领域逆向文章。内核/Crypto/PRNG/游戏作弊/协议/固件/硬件全覆盖。">
   <meta property="og:url" content="https://ling71671.github.io/open-reverselab/kb/general/">
   <link rel="canonical" href="https://ling71671.github.io/open-reverselab/kb/general/">
   <link rel="stylesheet" href="../../assets/css/style.css">
@@ -18,12 +18,13 @@
     "@context": "https://schema.org",
     "@type": "TechArticleSeries",
     "name": "ReverseLab General Knowledge Base",
-    "description": "17 articles: Linux kernel exploitation, crypto algorithm identification, PRNG cracking, game cheating/anti-cheat, protocol reversing (Protobuf), firmware/hardware/radio.",
-    "numberOfItems": 17,
+    "description": "12 articles: Linux kernel exploitation, crypto algorithm identification, PRNG cracking, game cheating/anti-cheat, protocol reversing (Protobuf), firmware/hardware/radio.",
+    "numberOfItems": 12,
     "inLanguage": "zh-CN",
     "isPartOf": {"@type": "SoftwareSourceCode", "name": "ReverseLab", "url": "https://github.com/LING71671/open-reverselab"}
   }
   </script>
+  <script src="../../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -45,7 +46,7 @@
 
     <section class="hero">
       <h2>🔬 General — 跨领域逆向工程</h2>
-      <p class="hero-desc">5 分类 · 17 篇技术文章。覆盖密码学、内核利用、游戏作弊、协议逆向、固件、硬件、无线电、AI 安全。</p>
+      <p class="hero-desc">8 分类 · 12 篇技术文章。覆盖密码学、内核利用、游戏作弊、协议逆向、固件、硬件、无线电、AI 安全。</p>
       <div class="hero-actions">
         <a href="https://github.com/LING71671/open-reverselab/tree/main/kb/general/techniques" class="btn-primary">GitHub 上浏览全部文章</a>
         <a href="https://github.com/LING71671/open-reverselab/blob/main/kb/general/techniques/attack-network.md" class="btn-secondary">查看攻击网图谱</a>

--- a/docs/kb/general/index.html
+++ b/docs/kb/general/index.html
@@ -11,6 +11,34 @@
   <meta property="og:description" content="12 篇跨领域逆向文章。内核/Crypto/PRNG/游戏作弊/协议/固件/硬件全覆盖。">
   <meta property="og:url" content="https://ling71671.github.io/open-reverselab/kb/general/">
   <link rel="canonical" href="https://ling71671.github.io/open-reverselab/kb/general/">
+  <script>
+    (function () {
+      try {
+        var key = 'reverselab-theme';
+        var theme = localStorage.getItem(key) || '';
+        var aliases = {
+          light: 'mint-apple', ash: 'dark', midnight: 'midnight-blurple', chroma: 'chroma-glow',
+          grape: 'retro', mocha: 'sepia', onyx: 'under-the-sea', aurora: 'forest'
+        };
+        if (aliases[theme]) theme = aliases[theme];
+        var valid = {
+          cinder:1,'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1,sunset:1,'chroma-glow':1,forest:1,crimson:1,
+          'midnight-blurple':1,mars:1,dusk:1,'under-the-sea':1,retro:1,'neon-nights':1,sepia:1,
+          blurple:1,dark:1
+        };
+        if (!valid[theme]) {
+          theme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'mint-apple';
+        }
+        var light = {
+          'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1
+        };
+        document.documentElement.setAttribute('data-theme', theme);
+        document.documentElement.style.colorScheme = light[theme] ? 'light' : 'dark';
+      } catch (e) {}
+    })();
+  </script>
   <link rel="stylesheet" href="../../assets/css/style.css">
   <link rel="icon" type="image/svg+xml" href="../../assets/img/favicon.svg">
   <script type="application/ld+json">

--- a/docs/kb/index.html
+++ b/docs/kb/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>知识库 | ReverseLab — 178 篇逆向工程技术文章</title>
-  <meta name="description" content="ReverseLab 知识库：178 篇深度逆向工程技术文章，覆盖 CTF Web 渗透、APK 逆向、PE 二进制分析、密码学/协议/内核/游戏作弊。每篇包含可运行代码、攻击链图谱、MCP 工具映射。">
+  <title>知识库 | ReverseLab — 197 篇逆向工程技术文章</title>
+  <meta name="description" content="ReverseLab 知识库：197 篇深度逆向工程技术文章，覆盖 CTF Web 渗透、APK 逆向、PE 二进制分析、密码学/协议/内核/游戏作弊。每篇包含可运行代码、攻击链图谱、MCP 工具映射。">
   <meta name="keywords" content="reverse engineering knowledge base, CTF techniques, APK reverse engineering, PE analysis, cryptography, exploit, 逆向工程知识库, 安全技术文章">
   <meta name="robots" content="index, follow">
-  <meta property="og:title" content="知识库 | ReverseLab — 178 篇逆向工程技术文章">
+  <meta property="og:title" content="知识库 | ReverseLab — 197 篇逆向工程技术文章">
   <meta property="og:description" content="覆盖 CTF Web / APK / PE / 密码学 / 协议 / 内核 / 游戏作弊的全领域逆向工程知识体系。">
   <meta property="og:url" content="https://ling71671.github.io/open-reverselab/kb/">
   <meta property="og:type" content="website">
@@ -15,6 +15,7 @@
   <link rel="canonical" href="https://ling71671.github.io/open-reverselab/kb/">
   <link rel="stylesheet" href="../assets/css/style.css">
   <link rel="icon" type="image/svg+xml" href="../assets/img/favicon.svg">
+  <script src="../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -39,7 +40,7 @@
     <section class="hero">
       <h2>📚 逆向工程知识库</h2>
       <p class="hero-desc">
-        178 篇深度技术文章，每篇包含：场景→输入信号→方法→攻击链→MCP 工具映射。
+        197 篇深度技术文章，每篇包含：场景→输入信号→方法→攻击链→MCP 工具映射。
         文章内容可直接复制运行，所有技术均配有可执行的 Python/JS/C++/Frida 代码。
       </p>
     </section>
@@ -51,25 +52,25 @@
           <span class="board-icon">🌐</span>
           <h3>CTF Website</h3>
           <p>Web 攻击全表面 — JWT / SQLi / SSRF / XSS / CSRF / CORS / OAuth / CVE / DoS / Payment / 签名攻击 / Paywall 绕过 / API 攻击 / 供应链 / 云原生</p>
-          <span class="board-stat">26 分类 · 118 篇</span>
+          <span class="board-stat">23 分类 · 97 篇</span>
         </a>
         <a href="apk-reverse/index.html" class="board-card">
           <span class="board-icon">📱</span>
           <h3>APK Reverse</h3>
           <p>Android 逆向 — DEX/Java / Native(IL2CPP, UE4) / 加密破解 / 网络协议 Hook / 动态插桩 / 脱壳 / 重打包</p>
-          <span class="board-stat">8 分类 · 20 篇</span>
+          <span class="board-stat">8 分类 · 17 篇</span>
         </a>
         <a href="pe-reverse/index.html" class="board-card">
           <span class="board-icon">🖥️</span>
           <h3>PE Reverse</h3>
           <p>Windows 二进制分析 — Triage / PE 结构 / Ghidra 静态分析 / x64dbg 动态分析 / 加密脱壳 / IOC 提取 / YARA / Sigma / Patch / 免杀</p>
-          <span class="board-stat">9 分类 · 22 篇</span>
+          <span class="board-stat">8 分类 · 18 篇</span>
         </a>
         <a href="general/index.html" class="board-card">
           <span class="board-icon">🔬</span>
           <h3>General</h3>
           <p>跨领域 — Linux 内核利用 / 加密算法识别与破解 / PRNG 攻击 / 游戏作弊与反作弊 / 协议逆向(Protobuf) / 方法论</p>
-          <span class="board-stat">5 分类 · 17 篇</span>
+          <span class="board-stat">8 分类 · 12 篇</span>
         </a>
         <a href="windows/index.html" class="board-card">
           <span class="board-icon">🪟</span>

--- a/docs/kb/index.html
+++ b/docs/kb/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>知识库 | ReverseLab — 197 篇逆向工程技术文章</title>
-  <meta name="description" content="ReverseLab 知识库：197 篇深度逆向工程技术文章，覆盖 CTF Web 渗透、APK 逆向、PE 二进制分析、密码学/协议/内核/游戏作弊。每篇包含可运行代码、攻击链图谱、MCP 工具映射。">
+  <title>知识库 | ReverseLab — 145 篇逆向工程技术文章</title>
+  <meta name="description" content="ReverseLab 知识库：145 篇深度逆向工程技术文章，覆盖 CTF Web 渗透、APK 逆向、PE 二进制分析、密码学/协议/内核/游戏作弊。每篇包含可运行代码、攻击链图谱、MCP 工具映射。">
   <meta name="keywords" content="reverse engineering knowledge base, CTF techniques, APK reverse engineering, PE analysis, cryptography, exploit, 逆向工程知识库, 安全技术文章">
   <meta name="robots" content="index, follow">
-  <meta property="og:title" content="知识库 | ReverseLab — 197 篇逆向工程技术文章">
+  <meta property="og:title" content="知识库 | ReverseLab — 145 篇逆向工程技术文章">
   <meta property="og:description" content="覆盖 CTF Web / APK / PE / 密码学 / 协议 / 内核 / 游戏作弊的全领域逆向工程知识体系。">
   <meta property="og:url" content="https://ling71671.github.io/open-reverselab/kb/">
   <meta property="og:type" content="website">
@@ -68,7 +68,7 @@
     <section class="hero">
       <h2>📚 逆向工程知识库</h2>
       <p class="hero-desc">
-        197 篇深度技术文章，每篇包含：场景→输入信号→方法→攻击链→MCP 工具映射。
+        145 篇深度技术文章，每篇包含：场景→输入信号→方法→攻击链→MCP 工具映射。
         文章内容可直接复制运行，所有技术均配有可执行的 Python/JS/C++/Frida 代码。
       </p>
     </section>

--- a/docs/kb/index.html
+++ b/docs/kb/index.html
@@ -13,6 +13,34 @@
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="ReverseLab">
   <link rel="canonical" href="https://ling71671.github.io/open-reverselab/kb/">
+  <script>
+    (function () {
+      try {
+        var key = 'reverselab-theme';
+        var theme = localStorage.getItem(key) || '';
+        var aliases = {
+          light: 'mint-apple', ash: 'dark', midnight: 'midnight-blurple', chroma: 'chroma-glow',
+          grape: 'retro', mocha: 'sepia', onyx: 'under-the-sea', aurora: 'forest'
+        };
+        if (aliases[theme]) theme = aliases[theme];
+        var valid = {
+          cinder:1,'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1,sunset:1,'chroma-glow':1,forest:1,crimson:1,
+          'midnight-blurple':1,mars:1,dusk:1,'under-the-sea':1,retro:1,'neon-nights':1,sepia:1,
+          blurple:1,dark:1
+        };
+        if (!valid[theme]) {
+          theme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'mint-apple';
+        }
+        var light = {
+          'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1
+        };
+        document.documentElement.setAttribute('data-theme', theme);
+        document.documentElement.style.colorScheme = light[theme] ? 'light' : 'dark';
+      } catch (e) {}
+    })();
+  </script>
   <link rel="stylesheet" href="../assets/css/style.css">
   <link rel="icon" type="image/svg+xml" href="../assets/img/favicon.svg">
   <script src="../assets/js/theme.js" defer></script>

--- a/docs/kb/pe-reverse/index.html
+++ b/docs/kb/pe-reverse/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>PE Reverse 知识库 | ReverseLab — Windows 二进制分析 22 篇</title>
-  <meta name="description" content="PE 逆向技术知识库：9 分类 22 篇文章，覆盖 PE Triage、PE 结构、TLS Callback、Ghidra 静态分析、动态 API 解析、x64dbg 动态分析、加密脱壳、IOC 提取、YARA/Sigma 规则、Patch、免杀。每篇含可运行代码。">
+  <title>PE Reverse 知识库 | ReverseLab — Windows 二进制分析 18 篇</title>
+  <meta name="description" content="PE 逆向技术知识库：8 分类 18 篇文章，覆盖 PE Triage、PE 结构、Ghidra 静态分析、x64dbg 动态分析、加密脱壳、IOC 提取、YARA/Sigma 规则、Patch、免杀。每篇含可运行代码。">
   <meta name="keywords" content="PE analysis, binary reverse engineering, Ghidra, x64dbg, malware analysis, YARA, Sigma, IOC, patch, AV evasion, PE 分析, 逆向, 恶意代码, 脱壳, 免杀">
   <meta name="robots" content="index, follow">
   <meta property="og:title" content="PE Reverse 知识库 | ReverseLab">
-  <meta property="og:description" content="9 分类 22 篇 Windows PE 逆向技术文章。Ghidra/x64dbg/TLS Callback/API Resolver/YARA/Sigma/Patch/免杀全覆盖。">
+  <meta property="og:description" content="8 分类 18 篇 Windows PE 逆向技术文章。Ghidra/x64dbg/Triage/YARA/Sigma/Patch/免杀全覆盖。">
   <meta property="og:url" content="https://ling71671.github.io/open-reverselab/kb/pe-reverse/">
   <link rel="canonical" href="https://ling71671.github.io/open-reverselab/kb/pe-reverse/">
   <link rel="stylesheet" href="../../assets/css/style.css">
@@ -18,12 +18,13 @@
     "@context": "https://schema.org",
     "@type": "TechArticleSeries",
     "name": "ReverseLab PE Reverse Engineering Knowledge Base",
-    "description": "9 categories, 22 articles: PE triage, PE structure, TLS callbacks, Ghidra static analysis, dynamic API resolution, x64dbg dynamic analysis, crypto unpacking, IOC extraction, YARA/Sigma, patching, AV evasion.",
-    "numberOfItems": 22,
+    "description": "8 categories, 18 articles: PE triage, PE structure, Ghidra static analysis, x64dbg dynamic analysis, crypto unpacking, IOC extraction, YARA/Sigma, patching, AV evasion.",
+    "numberOfItems": 18,
     "inLanguage": "zh-CN",
     "isPartOf": {"@type": "SoftwareSourceCode", "name": "ReverseLab", "url": "https://github.com/LING71671/open-reverselab"}
   }
   </script>
+  <script src="../../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -45,7 +46,7 @@
 
     <section class="hero">
       <h2>🖥️ PE Reverse — Windows 二进制分析</h2>
-      <p class="hero-desc">9 分类 · 22 篇技术文章。覆盖从初始 Triage 到最终免杀的完整分析流水线。</p>
+      <p class="hero-desc">8 分类 · 18 篇技术文章。覆盖从初始 Triage 到最终免杀的完整分析流水线。</p>
       <div class="hero-actions">
         <a href="https://github.com/LING71671/open-reverselab/tree/main/kb/pe-reverse/techniques" class="btn-primary">GitHub 上浏览全部文章</a>
         <a href="https://github.com/LING71671/open-reverselab/blob/main/kb/pe-reverse/techniques/attack-network.md" class="btn-secondary">查看攻击网图谱</a>
@@ -55,11 +56,11 @@
     <section class="kb-list">
       <h2>技术分类</h2>
       <div class="kb-category"><h3>01-triage — 初筛（1 篇）</h3><p>AOB 签名扫描与模式匹配</p></div>
-      <div class="kb-category"><h3>02-pe-structure — PE 结构（2 篇）</h3><p>PE 头/节表/导入表/导出表/重定位/TLS Callback 等结构分析</p></div>
-      <div class="kb-category"><h3>03-static-analysis — 静态分析（5 篇）</h3><p>Ghidra 反编译分析：函数重命名、类型恢复、交叉引用、调用图、字符串追踪、结构体恢复、动态 API 解析</p></div>
+      <div class="kb-category"><h3>02-pe-structure — PE 结构（1 篇）</h3><p>PE 头/节表/导入表/导出表/重定位等结构分析</p></div>
+      <div class="kb-category"><h3>03-static-analysis — 静态分析（4 篇）</h3><p>Ghidra 反编译分析：函数重命名、类型恢复、交叉引用、调用图、字符串追踪、结构体恢复</p></div>
       <div class="kb-category"><h3>04-dynamic-analysis — 动态分析（8 篇）</h3><p>x64dbg/x32dbg 调试：API 断点、内存断点、条件断点、Patch 验证。Procmon 行为观察、Frida 动态插桩</p></div>
       <div class="kb-category"><h3>05-crypto-unpack — 加密/脱壳（1 篇）</h3><p>加密算法识别、脱壳策略、PE crypto unpack plan</p></div>
-      <div class="kb-category"><h3>06-ioc-extraction — IOC 提取（2 篇）</h3><p>IOC（Indicators of Compromise）提取与整理：文件哈希、C2 域名/IP、注册表键值、互斥体名、持久化启动链</p></div>
+      <div class="kb-category"><h3>06-ioc-extraction — IOC 提取（1 篇）</h3><p>IOC（Indicators of Compromise）提取与整理：文件哈希、C2 域名/IP、注册表键值、互斥体名</p></div>
       <div class="kb-category"><h3>07-yara-sigma — 检测规则（1 篇）</h3><p>YARA 规则编写与 Sigma 规则转换，用于检测和 SIEM 集成</p></div>
       <div class="kb-category"><h3>08-patch — 补丁（1 篇）</h3><p>PE 二进制 Patch 技术：字节修改、模式替换、PE 头修正</p></div>
       <div class="kb-category"><h3>09-av-evasion — 免杀（1 篇）</h3><p>免杀技术：Shellcode 加密/混淆、Loader 合并、静态签名绕过</p></div>

--- a/docs/kb/pe-reverse/index.html
+++ b/docs/kb/pe-reverse/index.html
@@ -11,6 +11,34 @@
   <meta property="og:description" content="8 分类 18 篇 Windows PE 逆向技术文章。Ghidra/x64dbg/Triage/YARA/Sigma/Patch/免杀全覆盖。">
   <meta property="og:url" content="https://ling71671.github.io/open-reverselab/kb/pe-reverse/">
   <link rel="canonical" href="https://ling71671.github.io/open-reverselab/kb/pe-reverse/">
+  <script>
+    (function () {
+      try {
+        var key = 'reverselab-theme';
+        var theme = localStorage.getItem(key) || '';
+        var aliases = {
+          light: 'mint-apple', ash: 'dark', midnight: 'midnight-blurple', chroma: 'chroma-glow',
+          grape: 'retro', mocha: 'sepia', onyx: 'under-the-sea', aurora: 'forest'
+        };
+        if (aliases[theme]) theme = aliases[theme];
+        var valid = {
+          cinder:1,'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1,sunset:1,'chroma-glow':1,forest:1,crimson:1,
+          'midnight-blurple':1,mars:1,dusk:1,'under-the-sea':1,retro:1,'neon-nights':1,sepia:1,
+          blurple:1,dark:1
+        };
+        if (!valid[theme]) {
+          theme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'mint-apple';
+        }
+        var light = {
+          'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1
+        };
+        document.documentElement.setAttribute('data-theme', theme);
+        document.documentElement.style.colorScheme = light[theme] ? 'light' : 'dark';
+      } catch (e) {}
+    })();
+  </script>
   <link rel="stylesheet" href="../../assets/css/style.css">
   <link rel="icon" type="image/svg+xml" href="../../assets/img/favicon.svg">
   <script type="application/ld+json">

--- a/docs/kb/windows/index.html
+++ b/docs/kb/windows/index.html
@@ -9,6 +9,34 @@
   <meta property="og:title" content="Windows 知识库 | ReverseLab">
   <meta property="og:url" content="https://ling71671.github.io/open-reverselab/kb/windows/">
   <link rel="canonical" href="https://ling71671.github.io/open-reverselab/kb/windows/">
+  <script>
+    (function () {
+      try {
+        var key = 'reverselab-theme';
+        var theme = localStorage.getItem(key) || '';
+        var aliases = {
+          light: 'mint-apple', ash: 'dark', midnight: 'midnight-blurple', chroma: 'chroma-glow',
+          grape: 'retro', mocha: 'sepia', onyx: 'under-the-sea', aurora: 'forest'
+        };
+        if (aliases[theme]) theme = aliases[theme];
+        var valid = {
+          cinder:1,'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1,sunset:1,'chroma-glow':1,forest:1,crimson:1,
+          'midnight-blurple':1,mars:1,dusk:1,'under-the-sea':1,retro:1,'neon-nights':1,sepia:1,
+          blurple:1,dark:1
+        };
+        if (!valid[theme]) {
+          theme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'mint-apple';
+        }
+        var light = {
+          'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1
+        };
+        document.documentElement.setAttribute('data-theme', theme);
+        document.documentElement.style.colorScheme = light[theme] ? 'light' : 'dark';
+      } catch (e) {}
+    })();
+  </script>
   <link rel="stylesheet" href="../../assets/css/style.css">
   <link rel="icon" type="image/svg+xml" href="../../assets/img/favicon.svg">
   <script src="../../assets/js/theme.js" defer></script>

--- a/docs/kb/windows/index.html
+++ b/docs/kb/windows/index.html
@@ -11,6 +11,7 @@
   <link rel="canonical" href="https://ling71671.github.io/open-reverselab/kb/windows/">
   <link rel="stylesheet" href="../../assets/css/style.css">
   <link rel="icon" type="image/svg+xml" href="../../assets/img/favicon.svg">
+  <script src="../../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">

--- a/docs/mcp-tools/index.html
+++ b/docs/mcp-tools/index.html
@@ -11,6 +11,34 @@
   <meta property="og:description" content="AI Agent 可直接调用的 100+ 逆向工程 MCP 工具。CTF/APK/PE/通用全领域覆盖。逆向工程 × AI。">
   <meta property="og:url" content="https://ling71671.github.io/open-reverselab/mcp-tools/">
   <link rel="canonical" href="https://ling71671.github.io/open-reverselab/mcp-tools/">
+  <script>
+    (function () {
+      try {
+        var key = 'reverselab-theme';
+        var theme = localStorage.getItem(key) || '';
+        var aliases = {
+          light: 'mint-apple', ash: 'dark', midnight: 'midnight-blurple', chroma: 'chroma-glow',
+          grape: 'retro', mocha: 'sepia', onyx: 'under-the-sea', aurora: 'forest'
+        };
+        if (aliases[theme]) theme = aliases[theme];
+        var valid = {
+          cinder:1,'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1,sunset:1,'chroma-glow':1,forest:1,crimson:1,
+          'midnight-blurple':1,mars:1,dusk:1,'under-the-sea':1,retro:1,'neon-nights':1,sepia:1,
+          blurple:1,dark:1
+        };
+        if (!valid[theme]) {
+          theme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'mint-apple';
+        }
+        var light = {
+          'mint-apple':1,'citrus-sherbert':1,'retro-raincloud':1,hanami:1,sunrise:1,
+          'cotton-candy':1,lofi:1,'desert-khaki':1
+        };
+        document.documentElement.setAttribute('data-theme', theme);
+        document.documentElement.style.colorScheme = light[theme] ? 'light' : 'dark';
+      } catch (e) {}
+    })();
+  </script>
   <link rel="stylesheet" href="../assets/css/style.css">
   <link rel="icon" type="image/svg+xml" href="../assets/img/favicon.svg">
 

--- a/docs/mcp-tools/index.html
+++ b/docs/mcp-tools/index.html
@@ -27,6 +27,7 @@
     "isPartOf": {"@type": "SoftwareSourceCode", "name": "ReverseLab", "url": "https://github.com/LING71671/open-reverselab"}
   }
   </script>
+  <script src="../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">


### PR DESCRIPTION
## Summary
- Add a docs-site theme switcher with 14 Discord-inspired palettes (Dark / Light / Ash / Midnight / Chroma / Dusk / Cotton Candy / Sunset / Forest / Crimson / Grape / Mocha / Onyx / Aurora)
- Persist the selected theme in `localStorage` and keep it consistent across docs pages
- Hook `theme.js` into all docs HTML pages and expand CSS variables for multi-theme rendering

## Test plan
- [x] `node --check docs/assets/js/theme.js`
- [x] Browser verification: 14 options present, theme switches correctly
- [x] Theme persists after reload
- [x] Theme is shared between `docs/index.html` and `docs/kb/index.html`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-theme selector across documentation, including persisted theme preference and smooth theme switching.
  * Theme now initializes early and applies consistently at page load.
* **Content Updates**
  * Updated knowledge base totals and per-category/article counts across multiple sections.
  * Refreshed FAQ wording, questions, and contribution/responsible-use guidance.
  * Updated homepage/SEO counts to match current article totals.
* **Bug Fixes**
  * Ensured theme selection works on additional pages, including the 404 and tool/board-related pages.
* **Style**
  * Expanded theme styling (new variables, switcher UI, and improved header/visual theming + accessibility helpers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->